### PR TITLE
feat: tracked durable tests

### DIFF
--- a/.github/workflows/run-durable.yml
+++ b/.github/workflows/run-durable.yml
@@ -1,10 +1,24 @@
 name: Run Durable tests
 
 on:
-  # "workflow_dispatch" allows this workflow to be triggered manually or via API. This workflow is only meant for the CD
-  # manager to invoke and monitor.
+  # "workflow_dispatch" allows this workflow to be triggered manually or via API through the CD manager
   workflow_dispatch:
     inputs:
+      environment:
+        type: choice
+        description: Durable infrastructure to run tests against
+        required: true
+        default: "dev"
+        options:
+          - dev
+          - qa
+          - tnet
+          - prod
+      build_tag:
+        type: string
+        description: Build tag for image used for running tests
+        required: true
+        default: "latest"
       # The "job_id" input is needed for the CD manager to be able to track a workflow run as part of a CD manager job.
       # The GitHub API does not return the workflow run ID for a run created via the API. In order to track a workflow,
       # we're forced to inject the CD manager job ID via a tagged job step. This allows the CD manager to lookup
@@ -12,27 +26,9 @@ on:
       # Ref: https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#create-a-workflow-dispatch-event
       job_id:
         type: string
-        description: ⚠️ DO NOT SPECIFY MANUALLY ⚠️
+        description: Test job identifier
         required: true
-      # The "environment" input is used by the CD manager to target the right durable environment when initiating a test
-      # run. This value is communicated to the CD manager when a workflow job is scheduled, then sent back for this
-      # workflow to use when running tests.
-      environment:
-        type: choice
-        description: ⚠️ DO NOT SPECIFY MANUALLY ⚠️
-        required: true
-        options:
-          - dev
-          - qa
-          - tnet
-          - prod
-      # The "build_tag" input is used by the CD manager to use the right build image when initiating a test run. This
-      # value is communicated to the CD manager when a workflow job is scheduled, then sent back for this workflow to
-      # use when running tests.
-      build_tag:
-        type: string
-        description: ⚠️ DO NOT SPECIFY MANUALLY ⚠️
-        required: false
+        default: "manual"
 
 jobs:
   run-tests:

--- a/.github/workflows/run-durable.yml
+++ b/.github/workflows/run-durable.yml
@@ -1,0 +1,73 @@
+name: Run Durable tests
+
+on:
+  # "workflow_dispatch" allows this workflow to be triggered manually or via API. This workflow is only meant for the CD
+  # manager to invoke and monitor.
+  workflow_dispatch:
+    inputs:
+      # The "job_id" input is needed for the CD manager to be able to track a workflow run as part of a CD manager job.
+      # The GitHub API does not return the workflow run ID for a run created via the API. In order to track a workflow,
+      # we're forced to inject the CD manager job ID via a tagged job step. This allows the CD manager to lookup
+      # workflow runs and identify which one corresponds to a particular job so that it can be tracked.
+      # Ref: https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#create-a-workflow-dispatch-event
+      job_id:
+        type: string
+        description: ⚠️ DO NOT SPECIFY MANUALLY ⚠️
+        required: true
+      # The "environment" input is used by the CD manager to target the right durable environment when initiating a test
+      # run. This value is communicated to the CD manager when a workflow job is scheduled, then sent back for this
+      # workflow to use when running tests.
+      environment:
+        type: choice
+        description: ⚠️ DO NOT SPECIFY MANUALLY ⚠️
+        required: true
+        options:
+          - dev
+          - qa
+          - tnet
+          - prod
+      # The "build_tag" input is used by the CD manager to use the right build image when initiating a test run. This
+      # value is communicated to the CD manager when a workflow job is scheduled, then sent back for this workflow to
+      # use when running tests.
+      build_tag:
+        type: string
+        description: ⚠️ DO NOT SPECIFY MANUALLY ⚠️
+        required: false
+
+jobs:
+  run-tests:
+    name: Test
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        network: [dev, qa, tnet, prod]
+    steps:
+      -
+        # We're piggybacking on this step to inject the CD manager job ID into this workflow
+        name: ${{ github.event.inputs.job_id }}
+        uses: actions/checkout@v3
+      -
+        name: Test ${{ matrix.network }}
+        if: ${{ github.event.inputs.environment == matrix.network }}
+        env:
+          BUILD_TAG: ${{ github.event.inputs.build_tag }}
+        run: |
+          if [[ -z "$BUILD_TAG" ]]; then
+            BUILD_TAG=latest
+          fi
+          make DURABLE_ENV=${{ matrix.network }} durable-tests
+
+  collect-results:
+    name: Durable Test Results
+    if: ${{ github.event.inputs.job_id != null }}
+    runs-on: ubuntu-latest
+    needs: [run-tests]
+    steps:
+      - run: exit 1
+        # see https://stackoverflow.com/a/67532120/4907315
+        if: >-
+          ${{
+               contains(needs.*.result, 'failure')
+            || contains(needs.*.result, 'cancelled')
+          }}

--- a/.github/workflows/schedule-durable.yml
+++ b/.github/workflows/schedule-durable.yml
@@ -1,15 +1,21 @@
-name: Run Durable tests
+name: Schedule Durable tests
 
 on:
   schedule:
-    # Run every midnight UTC
-    - cron: "0 0 * * *"
-  workflow_dispatch: # manually triggered
+    - cron: "0 0/8 * * *" # Every 8 hours
+  workflow_dispatch:
     inputs:
       environment:
-        description: 'Environment name (one of: dev, qa, tnet, prod)'
+        type: choice
+        description: "Environment name"
         required: true
-        default: 'qa'
+        default: "all"
+        options:
+          - dev
+          - qa
+          - tnet
+          - prod
+          - all
 
 env:
   AWS_REGION: ${{ secrets.AWS_REGION }}
@@ -51,8 +57,8 @@ jobs:
       name: Build and Publish
       run: make BUILD_TAG=${{ steps.generate-build-tag.outputs.build_tag }} publish-suite
 
-  run-tests:
-    name: Test
+  schedule-job:
+    name: Schedule test job
     runs-on: ubuntu-latest
     needs:
       - publish-suite
@@ -64,22 +70,8 @@ jobs:
       -
         uses: actions/checkout@v3
       -
-        name: Test ${{ matrix.network }}
-        if: ${{ github.event.inputs.environment == null || github.event.inputs.environment == matrix.network }}
+        name: Schedule ${{ matrix.network }}
+        if: ${{ github.event.inputs.environment == 'all' || github.event.inputs.environment == matrix.network }}
         env:
           BUILD_TAG: ${{ needs.publish-suite.outputs.build_tag }}
-        run: make DURABLE_ENV=${{ matrix.network }} durable-tests
-
-  collect-results:
-    name: Durable Test Results
-    if: ${{ always() }}
-    runs-on: ubuntu-latest
-    needs: [run-tests]
-    steps:
-      - run: exit 1
-        # see https://stackoverflow.com/a/67532120/4907315
-        if: >-
-          ${{
-               contains(needs.*.result, 'failure')
-            || contains(needs.*.result, 'cancelled')
-          }}
+        run: make DURABLE_ENV=${{ matrix.network }} schedule-durable-tests

--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,10 @@ hermetic-tests:
 durable-tests:
 	BUILD_TAG="${BUILD_TAG}" IMAGE_NAME="${TEST_SUITE_IMAGE_NAME}" ./durable/durable-driver.sh ${DURABLE_ENV}
 
+.PHONY: schedule-durable-tests
+schedule-durable-tests:
+	BUILD_TAG="${BUILD_TAG}" ./ci-scripts/schedule_durable_tests.sh ${DURABLE_ENV}
+
 # TODO Remove this target:
 # Remove flavor concept from driver.
 # We should have a single test suite with different kinds of tests

--- a/ci-scripts/schedule_durable_tests.sh
+++ b/ci-scripts/schedule_durable_tests.sh
@@ -25,8 +25,7 @@ curl -s https://raw.githubusercontent.com/3box/pipeline-tools/develop/ci/scripts
         \"workflow\": {\"S\": \"run-durable.yml\"}, \
         \"inputs\":   {                             \
           \"M\": {                                  \
-            \"build_tag\":   {\"S\": \"$tag\"},     \
-            \"environment\": {\"S\": \"$network\"}  \
+            \"build_tag\": {\"S\": \"$tag\"},       \
           }                                         \
         }                                           \
       }                                             \

--- a/ci-scripts/schedule_durable_tests.sh
+++ b/ci-scripts/schedule_durable_tests.sh
@@ -7,8 +7,13 @@ ttl=$(date +%s -d "14 days")
 tag=${BUILD_TAG-latest}
 network=${1-dev}
 
-curl -s https://raw.githubusercontent.com/3box/pipeline-tools/develop/ci/scripts/schedule_job.sh | bash -s -- \
-  "$network"                                        \
+docker run --rm -i \
+  -e "AWS_REGION=$AWS_REGION" \
+  -e "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID" \
+  -e "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" \
+  -v ~/.aws:/root/.aws \
+  -v "$PWD":/aws \
+  amazon/aws-cli dynamodb put-item --table-name "ceramic-$network-ops" --item \
   "{                                                \
     \"id\":     {\"S\": \"$id\"},                   \
     \"job\":    {\"S\": \"$job_id\"},               \

--- a/ci-scripts/schedule_durable_tests.sh
+++ b/ci-scripts/schedule_durable_tests.sh
@@ -30,7 +30,7 @@ docker run --rm -i \
         \"workflow\": {\"S\": \"run-durable.yml\"}, \
         \"inputs\":   {                             \
           \"M\": {                                  \
-            \"build_tag\": {\"S\": \"$tag\"},       \
+            \"build_tag\": {\"S\": \"$tag\"}        \
           }                                         \
         }                                           \
       }                                             \

--- a/ci-scripts/schedule_durable_tests.sh
+++ b/ci-scripts/schedule_durable_tests.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+id=$(uuidgen)
+job_id=$(uuidgen)
+now=$(date +%s%N)
+ttl=$(date +%s -d "14 days")
+tag=${BUILD_TAG-latest}
+network=${1-dev}
+
+curl -s https://raw.githubusercontent.com/3box/pipeline-tools/develop/ci/scripts/schedule_job.sh | bash -s -- \
+  "$network"                                        \
+  "{                                                \
+    \"id\":     {\"S\": \"$id\"},                   \
+    \"job\":    {\"S\": \"$job_id\"},               \
+    \"ts\":     {\"N\": \"$now\"},                  \
+    \"ttl\":    {\"N\": \"$ttl\"},                  \
+    \"stage\":  {\"S\": \"queued\"},                \
+    \"type\":   {\"S\": \"workflow\"},              \
+    \"params\": {                                   \
+      \"M\": {                                      \
+        \"name\":     {\"S\": \"Durable Tests\"},   \
+        \"org\":      {\"S\": \"3box\"},            \
+        \"repo\":     {\"S\": \"ceramic-tests\"},   \
+        \"ref\":      {\"S\": \"main\"},            \
+        \"workflow\": {\"S\": \"run-durable.yml\"}, \
+        \"inputs\":   {                             \
+          \"M\": {                                  \
+            \"build_tag\":   {\"S\": \"$tag\"},     \
+            \"environment\": {\"S\": \"$network\"}  \
+          }                                         \
+        }                                           \
+      }                                             \
+    }                                               \
+  }"


### PR DESCRIPTION
This PR splits the durable tests workflow into two phases:
- The first phase is building and publishing the test image, then scheduling a workflow job with the CD manager via [this](https://github.com/3box/pipeline-tools/pull/53) PR.
- The second phase is running the tests once the CD manager initiates the workflow.