### PR TITLE
fix: inject correct .env path for durable tests

### DIFF
--- a/durable/durable-driver.sh
+++ b/durable/durable-driver.sh
@@ -31,6 +31,6 @@ docker run \
     -e AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}" \
     -e AWS_REGION="${AWS_REGION}" \
     -e DB_ENDPOINT="${DB_ENDPOINT}" \
-    -e STAGE="${DURABLE_ENV}" \
+    -e DOTENV_CONFIG_PATH="./env/.env.${DURABLE_ENV}" \
     -e TEST_SELECTOR="${TEST_SELECTOR}" \
     "${IMAGE_NAME}":"$tag"

--- a/suite/Dockerfile
+++ b/suite/Dockerfile
@@ -17,10 +17,8 @@ COPY env/ ./env
 
 RUN pnpm run build
 
-ENV STAGE "dev"
-
 # Set the default .env path for Jest to load
-ENV DOTENV_CONFIG_PATH "./env/.env.$STAGE"
+ENV DOTENV_CONFIG_PATH "./env/.env.dev"
 
 # Select all tests by default
 ENV TEST_SELECTOR "."

--- a/suite/docker-compose.yml
+++ b/suite/docker-compose.yml
@@ -26,7 +26,6 @@ services:
       - AWS_SECRET_ACCESS_KEY=.
       - DB_ENDPOINT=http://localstack:4566
       - DOCKER_HOST=unix:///var/run/docker.sock
-      - STAGE=dev
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock"
     depends_on:


### PR DESCRIPTION
All tests were defaulting to the "dev" settings and hitting the Dev nodes instead of the right nodes in each respective env. This change should fix that.