### PR TITLE
feat: ws1 1455 e2e test for get events

### DIFF
--- a/suite/src/__tests__/fast/get-events.test.ts
+++ b/suite/src/__tests__/fast/get-events.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from '@jest/globals'
 import fetch from 'cross-fetch'
 import { generateRandomEventId, generateRandomEvent } from '../../utils/rustCeramicHelpers'
 
-// const CeramicUrls = String(process.env.CERAMIC_URLS).split(',')
+const CeramicUrls = String(process.env.CERAMIC_URLS).split(',')
 
 async function postEvent(url: string, event: any) {
   let response = await fetch(url + '/ceramic/events', {
@@ -24,8 +24,7 @@ async function getEventData(url: string, eventId: string) {
 }
 
 describe('rust-ceramic e2e test', () => {
-  // const ceramicUrl = CeramicUrls[0]
-  const ceramicUrl = "http://127.0.0.1:5001"
+  const ceramicUrl = CeramicUrls[0]
   test('post and get event data, success', async () => {
     const eventId = generateRandomEventId()
     const event = generateRandomEvent(eventId)

--- a/suite/src/__tests__/fast/get-events.test.ts
+++ b/suite/src/__tests__/fast/get-events.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from '@jest/globals'
+import fetch from 'cross-fetch'
+import { generateRandomEventId, generateRandomEvent } from '../../utils/rustCeramicHelpers'
+
+const CeramicUrls = String(process.env.CERAMIC_URLS).split(',')
+
+
+async function postEvent(url: string, event: any) {
+  let response = await fetch(url + '/ceramic/events', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json', 
+    },
+    body: JSON.stringify(event),
+  })
+  if (!response.ok) {
+    throw new Error(`HTTP error! status: ${response.status}`);
+  }
+}
+
+async function getEventData(url: string, eventId: string) {
+  let response = await fetch(url + `/ceramic/events/${eventId}`)
+  console.log(response)
+  return response
+}
+
+describe('rust-ceramic e2e test', () => {
+  const ceramicUrl = CeramicUrls[0] 
+  // const ceramicUrl = "http://127.0.0.1:5001"
+  test('post and get event data, success', async () => {
+    const eventId = generateRandomEventId();
+    const event = generateRandomEvent(eventId);
+    // publishing the event to rust-ceramic
+    await postEvent(ceramicUrl, event)
+    // fetching the event from its event-id from rust-ceramic
+    const getResponse = await getEventData(ceramicUrl, eventId)
+    expect(getResponse.status).toEqual(200);
+    expect(await (getResponse.json())).toEqual({
+      "eventId": eventId,
+      "eventData": event.eventData
+    })
+  })
+
+  test('get event data for non-existing event', async () => {
+    const eventId = generateRandomEventId();
+    // fetching the event from its event-id from rust-ceramic
+    const getResponse = await getEventData(ceramicUrl, eventId)
+    const responseText = await getResponse.text();
+    expect(getResponse.status).toEqual(400);
+    expect(responseText).toContain('Event not found');
+    expect(responseText).toContain(eventId);
+    expect(getResponse.statusText).toContain('Bad Request');
+  })
+})

--- a/suite/src/__tests__/fast/get-events.test.ts
+++ b/suite/src/__tests__/fast/get-events.test.ts
@@ -4,17 +4,16 @@ import { generateRandomEventId, generateRandomEvent } from '../../utils/rustCera
 
 const CeramicUrls = String(process.env.CERAMIC_URLS).split(',')
 
-
 async function postEvent(url: string, event: any) {
   let response = await fetch(url + '/ceramic/events', {
     method: 'POST',
     headers: {
-      'Content-Type': 'application/json', 
+      'Content-Type': 'application/json',
     },
     body: JSON.stringify(event),
   })
   if (!response.ok) {
-    throw new Error(`HTTP error! status: ${response.status}`);
+    throw new Error(`HTTP error! status: ${response.status}`)
   }
 }
 
@@ -25,30 +24,29 @@ async function getEventData(url: string, eventId: string) {
 }
 
 describe('rust-ceramic e2e test', () => {
-  const ceramicUrl = CeramicUrls[0] 
-  // const ceramicUrl = "http://127.0.0.1:5001"
+  const ceramicUrl = CeramicUrls[0]
   test('post and get event data, success', async () => {
-    const eventId = generateRandomEventId();
-    const event = generateRandomEvent(eventId);
+    const eventId = generateRandomEventId()
+    const event = generateRandomEvent(eventId)
     // publishing the event to rust-ceramic
     await postEvent(ceramicUrl, event)
     // fetching the event from its event-id from rust-ceramic
     const getResponse = await getEventData(ceramicUrl, eventId)
-    expect(getResponse.status).toEqual(200);
-    expect(await (getResponse.json())).toEqual({
-      "eventId": eventId,
-      "eventData": event.eventData
+    expect(getResponse.status).toEqual(200)
+    expect(await getResponse.json()).toEqual({
+      eventId: eventId,
+      eventData: event.eventData,
     })
   })
 
   test('get event data for non-existing event', async () => {
-    const eventId = generateRandomEventId();
+    const eventId = generateRandomEventId()
     // fetching the event from its event-id from rust-ceramic
     const getResponse = await getEventData(ceramicUrl, eventId)
-    const responseText = await getResponse.text();
-    expect(getResponse.status).toEqual(400);
-    expect(responseText).toContain('Event not found');
-    expect(responseText).toContain(eventId);
-    expect(getResponse.statusText).toContain('Bad Request');
+    const responseText = await getResponse.text()
+    expect(getResponse.status).toEqual(400)
+    expect(responseText).toContain('Event not found')
+    expect(responseText).toContain(eventId)
+    expect(getResponse.statusText).toContain('Bad Request')
   })
 })

--- a/suite/src/__tests__/fast/get-events.test.ts
+++ b/suite/src/__tests__/fast/get-events.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from '@jest/globals'
 import fetch from 'cross-fetch'
 import { generateRandomEventId, generateRandomEvent } from '../../utils/rustCeramicHelpers'
 
-const CeramicUrls = String(process.env.CERAMIC_URLS).split(',')
+// const CeramicUrls = String(process.env.CERAMIC_URLS).split(',')
 
 async function postEvent(url: string, event: any) {
   let response = await fetch(url + '/ceramic/events', {
@@ -24,7 +24,8 @@ async function getEventData(url: string, eventId: string) {
 }
 
 describe('rust-ceramic e2e test', () => {
-  const ceramicUrl = CeramicUrls[0]
+  // const ceramicUrl = CeramicUrls[0]
+  const ceramicUrl = "http://127.0.0.1:5001"
   test('post and get event data, success', async () => {
     const eventId = generateRandomEventId()
     const event = generateRandomEvent(eventId)
@@ -47,6 +48,5 @@ describe('rust-ceramic e2e test', () => {
     expect(getResponse.status).toEqual(404)
     expect(responseText).toContain('Event not found')
     expect(responseText).toContain(eventId)
-    expect(getResponse.statusText).toContain('Bad Request')
   })
 })

--- a/suite/src/__tests__/fast/get-events.test.ts
+++ b/suite/src/__tests__/fast/get-events.test.ts
@@ -34,8 +34,8 @@ describe('rust-ceramic e2e test', () => {
     const getResponse = await getEventData(ceramicUrl, eventId)
     expect(getResponse.status).toEqual(200)
     expect(await getResponse.json()).toEqual({
-      eventId: eventId,
-      eventData: event.eventData,
+      id: eventId,
+      data: event.eventData,
     })
   })
 

--- a/suite/src/__tests__/fast/get-events.test.ts
+++ b/suite/src/__tests__/fast/get-events.test.ts
@@ -44,7 +44,7 @@ describe('rust-ceramic e2e test', () => {
     // fetching the event from its event-id from rust-ceramic
     const getResponse = await getEventData(ceramicUrl, eventId)
     const responseText = await getResponse.text()
-    expect(getResponse.status).toEqual(400)
+    expect(getResponse.status).toEqual(404)
     expect(responseText).toContain('Event not found')
     expect(responseText).toContain(eventId)
     expect(getResponse.statusText).toContain('Bad Request')

--- a/suite/src/utils/rustCeramicHelpers.ts
+++ b/suite/src/utils/rustCeramicHelpers.ts
@@ -1,28 +1,26 @@
 import { randomCID, EventID, StreamID } from '@ceramicnetwork/streamid'
 import { base16 } from 'multiformats/bases/base16'
-import { CARFactory } from "cartonne"
+import { CARFactory } from 'cartonne'
 import { base64 } from 'multiformats/bases/base64'
 import * as random from '@stablelib/random'
 
-export function generateRandomEventId (): string {
-    const modelID = new StreamID('model', randomCID())
-      const eventId =  base16.encode(EventID.createRandom(
-        "dev-unstable",
-        0,
-        {
-          separatorKey: 'model',
-          separatorValue: modelID.toString(),
-        }
-      ).bytes);
-    return eventId;
+export function generateRandomEventId(): string {
+  const modelID = new StreamID('model', randomCID())
+  const eventId = base16.encode(
+    EventID.createRandom('dev-unstable', 0, {
+      separatorKey: 'model',
+      separatorValue: modelID.toString(),
+    }).bytes,
+  )
+  return eventId
 }
 
-export function generateRandomEvent (eventId: string): any {
-    const carFactory = new CARFactory();
-    const car = carFactory.build().asV1();
-    car.put({ data: base64.encode(random.randomBytes(512)) }, { isRoot: true });
-    return {
-      "eventId": eventId,
-      "eventData": car.toString('base64'),
-    };
+export function generateRandomEvent(eventId: string): any {
+  const carFactory = new CARFactory()
+  const car = carFactory.build().asV1()
+  car.put({ data: base64.encode(random.randomBytes(512)) }, { isRoot: true })
+  return {
+    eventId: eventId,
+    eventData: car.toString('base64'),
   }
+}

--- a/suite/src/utils/rustCeramicHelpers.ts
+++ b/suite/src/utils/rustCeramicHelpers.ts
@@ -1,0 +1,28 @@
+import { randomCID, EventID, StreamID } from '@ceramicnetwork/streamid'
+import { base16 } from 'multiformats/bases/base16'
+import { CARFactory } from "cartonne"
+import { base64 } from 'multiformats/bases/base64'
+import * as random from '@stablelib/random'
+
+export function generateRandomEventId (): string {
+    const modelID = new StreamID('model', randomCID())
+      const eventId =  base16.encode(EventID.createRandom(
+        "dev-unstable",
+        0,
+        {
+          separatorKey: 'model',
+          separatorValue: modelID.toString(),
+        }
+      ).bytes);
+    return eventId;
+}
+
+export function generateRandomEvent (eventId: string): any {
+    const carFactory = new CARFactory();
+    const car = carFactory.build().asV1();
+    car.put({ data: base64.encode(random.randomBytes(512)) }, { isRoot: true });
+    return {
+      "eventId": eventId,
+      "eventData": car.toString('base64'),
+    };
+  }


### PR DESCRIPTION
E2E tests for fetching event data from event_id (string). 
Goal is to test the getEvent endpoint end-to-end.
Scenarios tested : 
Positive scenario: StatusCode 200 : Publish and event, and then fetch event data for the same event
Negative scenario: StatusCode 404 (Event Not found) : Fetch eventData for an eventId that does not exist

PR testing : 
Ran the setup locally : 
![Screenshot 2024-02-06 at 3 58 01 PM](https://github.com/3box/ceramic-tests/assets/25499838/182aae49-50e0-4f47-8e43-55be824cdd5c)


