### PR TITLE
chore: update nightly simulation rate and target

### DIFF
--- a/simulations/basic-simulation.yaml
+++ b/simulations/basic-simulation.yaml
@@ -4,7 +4,7 @@ metadata:
   name: recon
 spec:
   scenario: recon-event-sync # or recon-event-key-sync if you're using rust-ceramic without recon data
-  throttleRequests: 280 # include to define a "steady sync" scenario where the worker creates about this many events/second
-  successRequestTarget: 10 # override the default value of 300 to determine how many events must be synced per second to other peers in the network
+  throttleRequests: 300 # include to define a "steady sync" scenario where the worker creates about this many events/second
+  successRequestTarget: 200 # override the default value of 300 to determine how many events must be synced per second to other peers in the network
   users: 2 # increase to generate more events, 1 is probably sufficient for our 300/s goal
-  runTime: 2
+  runTime: 10


### PR DESCRIPTION
Target 300 rps (should be slightly above in practice, but we want to make sure we write at least that many). Error if any run is less than 200 rps. When we reduce the variations in the runs due to hardware differences, we can increase this value, but for now it's below the lowest value we've seen in 24 hours (238 rps).