### PR TITLE
feat: export the COMPOSEDB_ADMIN_SEEDS env via port-forward

### DIFF
--- a/port-forward.sh
+++ b/port-forward.sh
@@ -22,8 +22,11 @@ ceramic=5001
 offset=1
 step=1
 
+admin_private_key=$(kubectl $namespace_flag get secret ceramic-admin -o jsonpath="{.data['private-key']}" | base64 -d )
+
 COMPOSEDB_URLS=''
 CERAMIC_URLS=''
+COMPOSEDB_ADMIN_DID_SEEDS=''
 
 for pod in $(kubectl $namespace_flag get pods -l app=ceramic -o json | jq -r '.items[].metadata.name')
 do
@@ -34,16 +37,20 @@ do
     then
         COMPOSEDB_URLS="$COMPOSEDB_URLS,"
         CERAMIC_URLS="$CERAMIC_URLS,"
+        COMPOSEDB_ADMIN_DID_SEEDS="$COMPOSEDB_ADMIN_DID_SEEDS,"
     fi
 
 
     COMPOSEDB_URLS="${COMPOSEDB_URLS}http://localhost:$composedb_local"
     CERAMIC_URLS="${CERAMIC_URLS}http://localhost:$ceramic_local"
+    COMPOSEDB_ADMIN_DID_SEEDS="${COMPOSEDB_ADMIN_DID_SEEDS}${admin_private_key}"
 
     kubectl port-forward $namespace_flag "$pod" $composedb_local:$composedb $ceramic_local:$ceramic >/dev/null  &
 
     offset=$((offset + step))
 done
 
-export COMPOSEDB_URLS=$COMPOSEDB_URLS
-export CERAMIC_URLS=$CERAMIC_URLS
+
+export COMPOSEDB_URLS
+export CERAMIC_URLS
+export COMPOSEDB_ADMIN_DID_SEEDS


### PR DESCRIPTION
The port-forward script will now read the ceramic-admin secret and export the env var.