### PR TITLE
fix: give perf tests more resources

### DIFF
--- a/.github/workflows/hermetic.yml
+++ b/.github/workflows/hermetic.yml
@@ -121,6 +121,7 @@ jobs:
       -
         name: Test ${{ matrix.networks }}
         run: |
+          set -euxo pipefail
           export BUILD_TAG=${{ needs.generate-matrix.outputs.build_tag }}
           export TEST_NETWORK=./networks/${{ matrix.networks }}.yaml
           chmod +x ./bin/hermetic-driver

--- a/networks/basic-rust.yaml
+++ b/networks/basic-rust.yaml
@@ -7,7 +7,12 @@ spec:
   replicas: 2
   ceramic:
     - ipfs:
-        rust: { env: { CERAMIC_ONE_RECON: "true" } }
+        rust:
+          env:
+            CERAMIC_ONE_RECON: "true"
+          resourceLimits:
+            cpu: "4"
+            memory: "1Gi"
   # Use Kubo with CAS because it still needs pubsub
   cas:
     ipfs:


### PR DESCRIPTION
The github action for checking performance are failing on the non auto-pilot cluster.

This PR updates the action's network to use the same resources as the nightly-performance runs.
