### PR TITLE
fix: pass test job label to designate notification channel

### DIFF
--- a/ci-scripts/schedule_durable_tests.sh
+++ b/ci-scripts/schedule_durable_tests.sh
@@ -30,6 +30,7 @@ docker run --rm -i \
         \"repo\":     {\"S\": \"ceramic-tests\"},           \
         \"ref\":      {\"S\": \"$branch\"},                 \
         \"workflow\": {\"S\": \"run-durable.yml\"},         \
+        \"labels\":   {\"L\": [{\"S\": \"test\"}]},         \
         \"inputs\":   {                                     \
           \"M\": {                                          \
             \"build_tag\": {\"S\": \"$tag\"},               \


### PR DESCRIPTION
Using the new `labels` field enabled via [this](https://github.com/3box/pipeline-tools/pull/58) PR.