### PR TITLE
chore: use experimental get events route

### DIFF
--- a/suite/src/__tests__/fast/sync-events.test.ts
+++ b/suite/src/__tests__/fast/sync-events.test.ts
@@ -30,7 +30,7 @@ async function readEvents(url: string, model: StreamID) {
   let offset = 0;
   var startTime = Date.now();
   while (!complete) {
-    const fullUrl = url + `/ceramic/events/model/${model.toString()}?offset=${offset}`
+    const fullUrl = url + `/ceramic/experimental/events/model/${model.toString()}?offset=${offset}`
     const response = await fetch(fullUrl)
     expect(response.status).toEqual(200)
     const data = await response.json();


### PR DESCRIPTION
WS2-3008

We have a GET events by filter route that isn't officially supported and currently exists for testing and debugging (added in [this pr](https://github.com/ceramicnetwork/rust-ceramic/pull/286). Now we use it in tests so the official looking route can be deleted.