### PR TITLE
fix: for the use of pnmp v8

### DIFF
--- a/suite/Dockerfile
+++ b/suite/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:20-alpine
 
-RUN npm install -g pnpm
+RUN npm install -g pnpm@8
 
 WORKDIR /app
 


### PR DESCRIPTION
Image is failing to build with
```
#11 [6/7] RUN pnpm install
#11 0.554  ERR_PNPM_BAD_PM_VERSION  This project is configured to use v^8.8.0 of pnpm. Your current pnpm is v9.0.1
#11 ERROR: process "/bin/sh -c pnpm install" did not complete successfully: exit code: 1
```