### PR TITLE
chore: disable tests that store invalid ceramic events in recon

### DIFF
--- a/suite/src/__tests__/fast/get-events.test.ts
+++ b/suite/src/__tests__/fast/get-events.test.ts
@@ -29,7 +29,7 @@ async function postEvent(url: string, event: any) {
 
 describe('rust-ceramic e2e test', () => {
   const ceramicUrl = CeramicUrls[0]
-  test('post and get event data, success', async () => {
+  test.skip('post and get event data, success', async () => {
     const modelId = new StreamID('model', randomCID())
     const eventId = generateRandomEventId(modelId)
     const event = generateRandomEvent(eventId)

--- a/suite/src/__tests__/fast/sync-events.test.ts
+++ b/suite/src/__tests__/fast/sync-events.test.ts
@@ -78,7 +78,7 @@ async function waitForEventCount(urls: string[], model: StreamID, count: number,
   throw new Error(`waitForEventCount: timeout after ${retries} retries`)
 }
 
-describe('sync events', () => {
+describe.skip('sync events', () => {
   const firstNodeUrl = CeramicUrls[0]
   const secondNodeUrl = CeramicUrls[1]
 


### PR DESCRIPTION
Skip tests that store invalid/fake event data in ceramic one. Until we validate, the noise in durable environments is distracting, so it's better to turn them off while we sort out real vs phantom bugs.

We're also removing the event ID from the API, so these are going red while we stabilize. That's also distracting, so we can turn them back on when they are real, or can be replaced by the MID versions.

We do still have a sync test that verifies a document created on one node syncs to the other, we just don't have quite the same coverage of specific recon scenarios.