### PR TITLE
chore: increase user count for simulation

### DIFF
--- a/simulations/basic-simulation.yaml
+++ b/simulations/basic-simulation.yaml
@@ -3,8 +3,8 @@ kind: Simulation
 metadata:
   name: recon
 spec:
-  scenario: recon-event-sync # or recon-event-key-sync if you're using rust-ceramic without recon data
+  scenario: recon-event-sync 
   throttleRequests: 300 # include to define a "steady sync" scenario where the worker creates about this many events/second
   successRequestTarget: 200 # override the default value of 300 to determine how many events must be synced per second to other peers in the network
-  users: 2 # increase to generate more events, 1 is probably sufficient for our 300/s goal
+  users: 16 # increase to generate more events. having more uses a bit more RAM, but should be limited to the throttleRequests number
   runTime: 10


### PR DESCRIPTION
The api adds up to 10 ms of latency if there isn't enough traffic to flush early (3 requests). So 2 users were now hitting 8 ms requests instead of 1 ms, which caused 205/198 instead of the 275/250 we were getting before (with a required number of 200, even though were up from 91% to 96% of events synced). We add a few more users, which should still be throttled to the target rate of 300.

Compare the [failure](https://github.com/3box/ceramic-tests/actions/runs/8902327149/job/24448095212#step:6:127) to an older [success](https://github.com/3box/ceramic-tests/actions/runs/8840948790/job/24277257345#step:6:125) and notice the `POST create_new_event` Avg (ms) value difference. The API was changed recently in [this PR](https://github.com/ceramicnetwork/rust-ceramic/pull/324).

Kicked off [this run](https://github.com/3box/ceramic-tests/actions/runs/8902892539) to see the impact.