### PR TITLE
chore: c1 get event accepts CID now

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ There are some helpful scripts in this repo to make testing locally possible:
 
     # This will run "fast" tests locally using the newly exported env vars.
     cd suite
+    pnpm install # do NOT `pnpm run build`. if you do, remove the .build directory
     pnpm run test --testPathPattern fast
 ```
 >NOTE: The port-forward script will leave `kubectl` process running in the background to forward the ports.

--- a/suite/package.json
+++ b/suite/package.json
@@ -33,6 +33,7 @@
     "@composedb/client": "^0.7.1",
     "@composedb/devtools": "^0.7.1",
     "@ipld/dag-json": "^10.1.7",
+    "@ipld/dag-cbor": "^7.0.0",
     "@jest/globals": "^29.7.0",
     "@jest/reporters": "^29.7.0",
     "@stablelib/random": "^1.0.2",

--- a/suite/pnpm-lock.yaml
+++ b/suite/pnpm-lock.yaml
@@ -44,6 +44,9 @@ dependencies:
   '@composedb/devtools':
     specifier: ^0.7.1
     version: 0.7.1(@polkadot/util@7.9.2)(graphql@16.8.1)(typescript@4.9.5)
+  '@ipld/dag-cbor':
+    specifier: ^7.0.0
+    version: 7.0.3
   '@ipld/dag-json':
     specifier: ^10.1.7
     version: 10.2.0
@@ -138,14 +141,9 @@ devDependencies:
     version: 7.6.0
   ts-loader:
     specifier: ^9.4.4
-    version: 9.5.1(typescript@4.9.5)(webpack@5.90.3)
+    version: 9.5.1(typescript@4.9.5)(webpack@5.91.0)
 
 packages:
-
-  /@aashutoshrathi/word-wrap@1.2.6:
-    resolution: {integrity: sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==}
-    engines: {node: '>=0.10.0'}
-    dev: true
 
   /@adraffy/ens-normalize@1.10.0:
     resolution: {integrity: sha512-nA9XHtlAkYfJxY7bce8DcN7eKxWWCWkU+1GR9d+U6MbNpfwQp8TI7vqOsBsMcHoT4mBu2kypKoSKnghEzOOq5Q==}
@@ -1040,6 +1038,13 @@ packages:
       regenerator-runtime: 0.14.1
     dev: false
 
+  /@babel/runtime@7.24.5:
+    resolution: {integrity: sha512-Nms86NXrsaeU9vbBJKni6gXiEXZ4CVpYVzEjDH9Sb8vmZ3UljyA1GSOJl/6LGPO8EHLuSF9H+IxNXHPX8QHJ4g==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      regenerator-runtime: 0.14.1
+    dev: false
+
   /@babel/runtime@7.6.0:
     resolution: {integrity: sha512-89eSBLJsxNxOERC0Op4vd+0Bqm6wRMqMbFtV3i0/fbaWw/mJ8Q3eBvgX0G4SyrOOLCtbu98HspF8o09MRT+KzQ==}
     dependencies:
@@ -1855,7 +1860,7 @@ packages:
       '@noble/curves': 1.4.0
       '@noble/hashes': 1.4.0
       '@stablelib/random': 1.0.2
-      caip: 1.1.0
+      caip: 1.1.1
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -2420,7 +2425,7 @@ packages:
     resolution: {integrity: sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==}
     engines: {node: '>=10.10.0'}
     dependencies:
-      '@humanwhocodes/object-schema': 2.0.2
+      '@humanwhocodes/object-schema': 2.0.3
       debug: 4.3.4
       minimatch: 3.1.2
     transitivePeerDependencies:
@@ -2432,8 +2437,8 @@ packages:
     engines: {node: '>=12.22'}
     dev: true
 
-  /@humanwhocodes/object-schema@2.0.2:
-    resolution: {integrity: sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==}
+  /@humanwhocodes/object-schema@2.0.3:
+    resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
     dev: true
 
   /@ipld/dag-cbor@7.0.3:
@@ -3116,7 +3121,7 @@ packages:
     resolution: {integrity: sha512-6ABY6ErgkCsM4C6+X+AJSY4pBGwbKlHZmUtHftaiTvbaj4XuA4nTo3GU28jw8wY0Jh2cJZJvt6/BJ5GVkm5tBA==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@babel/runtime': 7.24.0
+      '@babel/runtime': 7.24.5
       '@polkadot/x-textdecoder': 7.9.2
       '@polkadot/x-textencoder': 7.9.2
       '@types/bn.js': 4.11.6
@@ -3178,7 +3183,7 @@ packages:
     resolution: {integrity: sha512-wfwbSHXPhrOAl12QvlIOGNkMH/N/h8PId2ytIjvM/8zPPFB5Il6DWSFLtVapOGEpIFjEWbd5t8Td4pHBVXIEbg==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@babel/runtime': 7.24.0
+      '@babel/runtime': 7.24.5
       '@polkadot/x-global': 7.9.2
     dev: false
 
@@ -3186,7 +3191,7 @@ packages:
     resolution: {integrity: sha512-A19wwYINuZwU2dUyQ/mMzB0ISjyfc4cISfL4zCMUAVgj7xVoXMYV2GfjNdMpA8Wsjch3su6pxLbtJ2wU03sRTQ==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@babel/runtime': 7.24.0
+      '@babel/runtime': 7.24.5
       '@polkadot/x-global': 7.9.2
     dev: false
 
@@ -3242,8 +3247,8 @@ packages:
     requiresBuild: true
     dev: false
 
-  /@scure/base@1.1.5:
-    resolution: {integrity: sha512-Brj9FiG2W1MRQSTB212YVPRrcbjkv48FoZi/u4l/zds/ieRrqsh7aUf6CLwkAq61oKXr/ZlTzlY66gLIj3TFTQ==}
+  /@scure/base@1.1.6:
+    resolution: {integrity: sha512-ok9AWwhcgYuGG3Zfhyqg+zwl+Wn5uE+dwC0NV/2qQkx4dABbb/bx96vWu8NSj+BNjjSjno+JRYRjle1jV08k3g==}
     dev: false
 
   /@scure/bip32@1.3.2:
@@ -3251,21 +3256,21 @@ packages:
     dependencies:
       '@noble/curves': 1.2.0
       '@noble/hashes': 1.3.2
-      '@scure/base': 1.1.5
+      '@scure/base': 1.1.6
     dev: false
 
   /@scure/bip39@1.1.0:
     resolution: {integrity: sha512-pwrPOS16VeTKg98dYXQyIjJEcWfz7/1YJIwxUEPFfQPtc86Ym/1sVgQ2RLoD43AazMk2l/unK4ITySSpW2+82w==}
     dependencies:
       '@noble/hashes': 1.1.5
-      '@scure/base': 1.1.5
+      '@scure/base': 1.1.6
     dev: false
 
   /@scure/bip39@1.2.1:
     resolution: {integrity: sha512-Z3/Fsz1yr904dduJD0NpiyRHhRYHdcnyh73FZWiV+/qhWi83wNJ3NWolYqCEN+ZWsUz2TWwajJggcRE9r1zUYg==}
     dependencies:
       '@noble/hashes': 1.3.2
-      '@scure/base': 1.1.5
+      '@scure/base': 1.1.6
     dev: false
 
   /@sideway/address@4.1.5:
@@ -3919,7 +3924,7 @@ packages:
   /@types/bn.js@4.11.6:
     resolution: {integrity: sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==}
     dependencies:
-      '@types/node': 16.18.89
+      '@types/node': 16.18.97
     dev: false
 
   /@types/bn.js@5.1.5:
@@ -3943,12 +3948,12 @@ packages:
   /@types/eslint-scope@3.7.7:
     resolution: {integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==}
     dependencies:
-      '@types/eslint': 8.56.5
+      '@types/eslint': 8.56.10
       '@types/estree': 1.0.5
     dev: true
 
-  /@types/eslint@8.56.5:
-    resolution: {integrity: sha512-u5/YPJHo1tvkSF2CE0USEkxon82Z5DBy2xR+qfyYNszpX9qcs4sT6uq2kBbj4BXY1+DBGDPnrhMZV3pKWGNukw==}
+  /@types/eslint@8.56.10:
+    resolution: {integrity: sha512-Shavhk87gCtY2fhXDctcfS3e6FdxWkCx1iUZ9eEUbh7rTqlZT0/IzOkCOVt0fCjcFuZ9FPYfuezTBImfHCDBGQ==}
     dependencies:
       '@types/estree': 1.0.5
       '@types/json-schema': 7.0.15
@@ -4012,6 +4017,9 @@ packages:
 
   /@types/node@16.18.89:
     resolution: {integrity: sha512-QlrE8QI5z62nfnkiUZysUsAaxWaTMoGqFVcB3PvK1WxJ0c699bacErV4Fabe9Hki6ZnaHalgzihLbTl2d34XfQ==}
+
+  /@types/node@16.18.97:
+    resolution: {integrity: sha512-4muilE1Lbfn57unR+/nT9AFjWk0MtWi5muwCEJqnOvfRQDbSfLCUdN7vCIg8TYuaANfhLOV85ve+FNpiUsbSRg==}
 
   /@types/node@18.19.24:
     resolution: {integrity: sha512-eghAz3gnbQbvnHqB+mgB2ZR3aH6RhdEmHGS48BnV75KceQPHqabkxKI0BbUSsqhqy2Ddhc2xD/VAR9ySZd57Lw==}
@@ -5102,6 +5110,10 @@ packages:
     resolution: {integrity: sha512-yOO3Fu4ygyKYAdznuoaqschMKIZzcdgyMpBNtrIfrUhnOeaOWG+dh0c13wcOS6B/46IGGbncoyzJlio79jU7rw==}
     dev: false
 
+  /caip@1.1.1:
+    resolution: {integrity: sha512-a3v5lteUUOoyRI0U6qe5ayCCGkF2mCmJ5zQMDnOD2vRjgRg6sm9p8TsRC2h4D4beyqRN9RYniphAPnj/+jQC6g==}
+    dev: false
+
   /call-bind@1.0.7:
     resolution: {integrity: sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==}
     engines: {node: '>= 0.4'}
@@ -5629,7 +5641,7 @@ packages:
       '@noble/ciphers': 0.4.1
       '@noble/curves': 1.4.0
       '@noble/hashes': 1.4.0
-      '@scure/base': 1.1.5
+      '@scure/base': 1.1.6
       canonicalize: 2.0.0
       did-resolver: 4.1.0
       multibase: 4.0.6
@@ -5808,6 +5820,14 @@ packages:
       tapable: 2.2.1
     dev: true
 
+  /enhanced-resolve@5.16.1:
+    resolution: {integrity: sha512-4U5pNsuDl0EhuZpq46M5xPslstkviJuhrdobaRDBk2Jy2KO37FDAJl4lb2KlNabxT0m4MTK2UHNrsAcphE8nyw==}
+    engines: {node: '>=10.13.0'}
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.2.1
+    dev: true
+
   /env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
@@ -5943,8 +5963,8 @@ packages:
       safe-array-concat: 1.1.2
     dev: true
 
-  /es-module-lexer@1.4.1:
-    resolution: {integrity: sha512-cXLGjP0c4T3flZJKQSuziYoq7MlT+rnvfZjfp7h+I7K9BNX54kP9nyWvdbwjQ4u1iWbOL4u96fgeZLToQlZC7w==}
+  /es-module-lexer@1.5.2:
+    resolution: {integrity: sha512-l60ETUTmLqbVbVHv1J4/qj+M8nq7AwMzEcg3kmJDt9dCNrTk+yHcYFf/Kw75pMDwd9mPcIGCG5LcS20SxYRzFA==}
     dev: true
 
   /es-set-tostringtag@2.0.3:
@@ -6258,7 +6278,7 @@ packages:
       lodash.merge: 4.6.2
       minimatch: 3.1.2
       natural-compare: 1.4.0
-      optionator: 0.9.3
+      optionator: 0.9.4
       strip-ansi: 6.0.1
       text-table: 0.2.0
     transitivePeerDependencies:
@@ -7973,7 +7993,7 @@ packages:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 16.18.89
+      '@types/node': 16.18.97
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: true
@@ -9030,16 +9050,16 @@ packages:
     hasBin: true
     dev: false
 
-  /optionator@0.9.3:
-    resolution: {integrity: sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==}
+  /optionator@0.9.4:
+    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
     dependencies:
-      '@aashutoshrathi/word-wrap': 1.2.6
       deep-is: 0.1.4
       fast-levenshtein: 2.0.6
       levn: 0.4.1
       prelude-ls: 1.2.1
       type-check: 0.4.0
+      word-wrap: 1.2.5
     dev: true
 
   /p-cancelable@0.3.0:
@@ -10005,9 +10025,6 @@ packages:
   /sqlite3@5.1.7:
     resolution: {integrity: sha512-GGIyOiFaG+TUra3JIfkI/zGP8yZYLPQ0pl1bH+ODjiX57sPhrLU5sQJn1y9bDKZUFYkX1crlrPfSYt0BKKdkog==}
     requiresBuild: true
-    peerDependenciesMeta:
-      node-gyp:
-        optional: true
     dependencies:
       bindings: 1.5.0
       node-addon-api: 7.1.0
@@ -10282,7 +10299,7 @@ packages:
       uuid: 3.4.0
     dev: false
 
-  /terser-webpack-plugin@5.3.10(webpack@5.90.3):
+  /terser-webpack-plugin@5.3.10(webpack@5.91.0):
     resolution: {integrity: sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -10302,12 +10319,12 @@ packages:
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.2
-      terser: 5.29.2
-      webpack: 5.90.3
+      terser: 5.31.0
+      webpack: 5.91.0
     dev: true
 
-  /terser@5.29.2:
-    resolution: {integrity: sha512-ZiGkhUBIM+7LwkNjXYJq8svgkd+QK3UUr0wJqY4MieaezBSAIPgbSPZyIx0idM6XWK5CMzSWa8MJIzmRcB8Caw==}
+  /terser@5.31.0:
+    resolution: {integrity: sha512-Q1JFAoUKE5IMfI4Z/lkE/E6+SwgzO+x4tq4v1AyBLRj8VSYvRO6A/rQrPg1yud4g0En9EKI1TvFRF2tQFcoUkg==}
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
@@ -10445,7 +10462,7 @@ packages:
       yargs-parser: 21.1.1
     dev: false
 
-  /ts-loader@9.5.1(typescript@4.9.5)(webpack@5.90.3):
+  /ts-loader@9.5.1(typescript@4.9.5)(webpack@5.91.0):
     resolution: {integrity: sha512-rNH3sK9kGZcH9dYzC7CewQm4NtxJTjSEVRJ2DyBZR7f8/wcta+iV44UPCXc5+nzDzivKtlzV6c9P4e+oFhDLYg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
@@ -10458,7 +10475,7 @@ packages:
       semver: 7.6.0
       source-map: 0.7.4
       typescript: 4.9.5
-      webpack: 5.90.3
+      webpack: 5.91.0
     dev: true
 
   /tsconfig-paths@3.15.0:
@@ -10780,8 +10797,8 @@ packages:
     engines: {node: '>=10.13.0'}
     dev: true
 
-  /webpack@5.90.3:
-    resolution: {integrity: sha512-h6uDYlWCctQRuXBs1oYpVe6sFcWedl0dpcVaTf/YF67J9bKvwJajFulMVSYKHrksMB3I/pIagRzDxwxkebuzKA==}
+  /webpack@5.91.0:
+    resolution: {integrity: sha512-rzVwlLeBWHJbmgTC/8TvAcu5vpJNII+MelQpylD4jNERPwpBJOE2lEcko1zJX3QJeLjTTAnQxn/OJ8bjDzVQaw==}
     engines: {node: '>=10.13.0'}
     hasBin: true
     peerDependencies:
@@ -10799,8 +10816,8 @@ packages:
       acorn-import-assertions: 1.9.0(acorn@8.11.3)
       browserslist: 4.23.0
       chrome-trace-event: 1.0.3
-      enhanced-resolve: 5.16.0
-      es-module-lexer: 1.4.1
+      enhanced-resolve: 5.16.1
+      es-module-lexer: 1.5.2
       eslint-scope: 5.1.1
       events: 3.3.0
       glob-to-regexp: 0.4.1
@@ -10811,7 +10828,7 @@ packages:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(webpack@5.90.3)
+      terser-webpack-plugin: 5.3.10(webpack@5.91.0)
       watchpack: 2.4.1
       webpack-sources: 3.2.3
     transitivePeerDependencies:
@@ -10903,6 +10920,11 @@ packages:
     dependencies:
       bs58check: 2.1.2
     dev: false
+
+  /word-wrap@1.2.5:
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
+    dev: true
 
   /wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}

--- a/suite/src/__tests__/fast/get-events.test.ts
+++ b/suite/src/__tests__/fast/get-events.test.ts
@@ -45,8 +45,7 @@ describe('rust-ceramic e2e test', () => {
   })
 
   test('get event data for non-existing event', async () => {
-    const modelId = new StreamID('model', randomCID())
-    const eventId = generateRandomEventId(modelId)
+    const eventId = randomCID().toString()
     // fetching the event from its event-id from rust-ceramic
     const getResponse = await getEventData(ceramicUrl, eventId)
     const responseText = await getResponse.text()

--- a/suite/src/__tests__/fast/get-events.test.ts
+++ b/suite/src/__tests__/fast/get-events.test.ts
@@ -1,20 +1,20 @@
 import { describe, expect, test } from '@jest/globals'
 import fetch from 'cross-fetch'
-import { generateRandomEventId, generateRandomEvent } from '../../utils/rustCeramicHelpers'
+import { ReconEventInput, generateRandomEvent } from '../../utils/rustCeramicHelpers'
 import { StreamID, randomCID } from '@ceramicnetwork/streamid'
 
 const CeramicUrls = String(process.env.CERAMIC_URLS).split(',')
 
 
-async function getEventData(url: string, eventId: string, log = false) {
-  let response = await fetch(url + `/ceramic/events/${eventId}`)
+async function getEventData(url: string, eventCid: string, log = false) {
+  let response = await fetch(url + `/ceramic/events/${eventCid}`)
   if (log) {
     console.log(response)
   }
   return response
 }
 
-async function postEvent(url: string, event: any) {
+async function postEvent(url: string, event: ReconEventInput) {
   let response = await fetch(url + '/ceramic/events', {
     method: 'POST',
     headers: {
@@ -23,25 +23,21 @@ async function postEvent(url: string, event: any) {
     body: JSON.stringify(event),
   })
   if (!response.ok) {
-    throw new Error(`HTTP error! status: ${response.status}`)
+    throw new Error(`HTTP error! status: ${response.status} ${response.statusText}`)
   }
 }
 
 describe('rust-ceramic e2e test', () => {
   const ceramicUrl = CeramicUrls[0]
-  test.skip('post and get event data, success', async () => {
+  test('post and get event data, success', async () => {
     const modelId = new StreamID('model', randomCID())
-    const eventId = generateRandomEventId(modelId)
-    const event = generateRandomEvent(eventId)
+    const event = generateRandomEvent(modelId, 'did:key:faketestcontroller')
     // publishing the event to rust-ceramic
-    await postEvent(ceramicUrl, event)
+    await postEvent(ceramicUrl, { data: event.data })
     // fetching the event from its event-id from rust-ceramic
-    const getResponse = await getEventData(ceramicUrl, eventId)
+    const getResponse = await getEventData(ceramicUrl, event.id)
     expect(getResponse.status).toEqual(200)
-    expect(await getResponse.json()).toEqual({
-      id: eventId,
-      data: event.data,
-    })
+    expect(await getResponse.json()).toEqual(event)
   })
 
   test('get event data for non-existing event', async () => {

--- a/suite/src/__tests__/fast/sync-events.test.ts
+++ b/suite/src/__tests__/fast/sync-events.test.ts
@@ -2,25 +2,31 @@ import { beforeAll, describe, expect, test } from '@jest/globals'
 import { utilities } from '../../utils/common.js'
 import fetch from 'cross-fetch'
 import { randomCID, StreamID } from '@ceramicnetwork/streamid'
-import { randomEvents, ReconEvent } from '../../utils/rustCeramicHelpers.js'
+import { ReconEvent, ReconEventInput, randomEvents } from '../../utils/rustCeramicHelpers.js'
 
 const delay = utilities.delay
 // Environment variables
 const CeramicUrls = String(process.env.CERAMIC_URLS).split(',')
 async function registerInterest(url: string, model: StreamID) {
   let response = await fetch(url + `/ceramic/interests/model/${model.toString()}`, { method: 'POST' })
+  if (response.status !== 204) {
+    const data = await response.text()
+    console.warn(`registerInterest: ${data}`)
+  }
   expect(response.status).toEqual(204)
-  await response.text()
 }
 
-async function writeEvents(url: string, events: any[]) {
+async function writeEvents(url: string, events: ReconEventInput[]) {
   for (const event of events) {
     let response = await fetch(url + '/ceramic/events', {
       method: 'POST',
       body: JSON.stringify(event),
     })
+    if (response.status !== 204) {
+      const data = await response.text()
+      console.warn(`writeEvents: ${data}`)
+    }
     expect(response.status).toEqual(204)
-    await response.text()
   }
 }
 
@@ -78,7 +84,7 @@ async function waitForEventCount(urls: string[], model: StreamID, count: number,
   throw new Error(`waitForEventCount: timeout after ${retries} retries`)
 }
 
-describe.skip('sync events', () => {
+describe('sync events', () => {
   const firstNodeUrl = CeramicUrls[0]
   const secondNodeUrl = CeramicUrls[1]
 


### PR DESCRIPTION
This change is made in order to stay compatible with the [new ceramic one api](https://github.com/ceramicnetwork/rust-ceramic/pull/327), where we accept CID instead of EventID. The recon input and output are now different, so I created a second interface to help get the create/assert right.

I made some adjustments to events and we now build a valid ceramic deterministic event so that recon can parse and sync it. I used the unique field of a deterministic event to avoid signing and make sure they were different so that recon would sync each of them.