### PR TITLE
fix: shorten basic-rust network ttl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ HERMETIC_CMD ?= ${CARGO_RUN} --bin hermetic-driver --
 HERMETIC_SUFFIX ?= ${BUILD_TAG}
 
 # TTL for cleaning up network after tests (defaults to 8 hours)
-HERMETIC_TTL ?= 28800
+HERMETIC_TTL ?= 3600
 
 # Environment to run durable tests against
 DURABLE_ENV ?= dev

--- a/networks/basic-rust.yaml
+++ b/networks/basic-rust.yaml
@@ -23,4 +23,3 @@ spec:
       go: {}
   monitoring:
     namespaced: true
-  ttlSeconds: 3600

--- a/networks/basic-rust.yaml
+++ b/networks/basic-rust.yaml
@@ -23,3 +23,4 @@ spec:
       go: {}
   monitoring:
     namespaced: true
+  ttlSeconds: 3600


### PR DESCRIPTION
We're tying up lots of node resources in GCP with idle tests.

This should clean them up after an hour.

