### PR TITLE
chore: skip data feed tests

### DIFF
--- a/suite/src/__tests__/fast/data-feed-api.test.ts
+++ b/suite/src/__tests__/fast/data-feed-api.test.ts
@@ -24,7 +24,7 @@ async function genesisCommit(ceramicNode: CeramicClient, modelInstanceDocumentMe
   )
 }
 
-describe('Datafeed SSE Api Test', () => {
+describe.skip('Datafeed SSE Api Test', () => {
   let ceramicNode1: CeramicClient
   let ceramicNode2: CeramicClient
   let modelId: StreamID


### PR DESCRIPTION
Skip data feed correctness test until we know what causes the delay.