### PR TITLE
fix: add timeout to wait for model to index and load

### DIFF
--- a/suite/src/__tests__/fast/model-correctness.test.ts
+++ b/suite/src/__tests__/fast/model-correctness.test.ts
@@ -36,16 +36,16 @@ describe('Model Integration Test', () => {
     )
     await ceramicNode1.admin.startIndexingModels([model.id])
     await ceramicNode2.admin.startIndexingModels([model.id])
-    modelId = model.id
-  })
-
-  test('Create a ModelInstanceDocument on one node and read it from another', async () => {
     await waitForIndexingOrTimeout(
       ceramicNode1,
       ceramicNode2,
       modelId,
       1000 * 60 * indexWaitTimeMin,
     )
+    modelId = model.id
+  })
+
+  test('Create a ModelInstanceDocument on one node and read it from another', async () => {
     const modelInstanceDocumentMetadata = { model: modelId }
     const document1 = await ModelInstanceDocument.create(
       ceramicNode1,

--- a/suite/src/__tests__/fast/model-correctness.test.ts
+++ b/suite/src/__tests__/fast/model-correctness.test.ts
@@ -7,13 +7,11 @@ import { ModelInstanceDocument } from '@ceramicnetwork/stream-model-instance'
 import { newModel, basicModelDocumentContent } from '../../models/modelConstants'
 import { CeramicClient } from '@ceramicnetwork/http-client'
 import { CommonTestUtils as TestUtils } from '@ceramicnetwork/common-test-utils'
-import { utilities } from '../../utils/common.js'
 import { loadDocumentOrTimeout } from '../../utils/composeDbHelpers.js'
 
-const delay = utilities.delay
 const ComposeDbUrls = String(process.env.COMPOSEDB_URLS).split(',')
 const adminSeeds = String(process.env.COMPOSEDB_ADMIN_DID_SEEDS).split(',')
-const nodeSyncWaitTimeSec = 2
+const nodeSyncWaitTimeMin = 2
 
 describe('Model Integration Test', () => {
   let ceramicNode1: CeramicClient
@@ -45,7 +43,7 @@ describe('Model Integration Test', () => {
       const indexedModels1 = await ceramicNode1.admin.getIndexedModels();
       const indexedModels2 = await ceramicNode2.admin.getIndexedModels();
       return indexedModels1.includes(modelId) && indexedModels2.includes(modelId);
-    }, 1000 * 60 * nodeSyncWaitTimeSec); // 3 minute timeout in millseconds
+    }, 1000 * 60 * nodeSyncWaitTimeMin); // 1 minute timeout in millseconds
     if (!isIndexed) {
       throw new Error('Timeout reached: Failed to index the model')
     }
@@ -55,9 +53,7 @@ describe('Model Integration Test', () => {
       basicModelDocumentContent,
       modelInstanceDocumentMetadata,
     )
-    // We have to wait for some time for sync to happen
-    await delay(nodeSyncWaitTimeSec)
-    const document2 = await loadDocumentOrTimeout(ceramicNode2, document1.id, 1000 * nodeSyncWaitTimeSec)
+    const document2 = await loadDocumentOrTimeout(ceramicNode2, document1.id, 1000 * 60 * nodeSyncWaitTimeMin)
     expect(document2.id).toEqual(document1.id)
   })
 })

--- a/suite/src/__tests__/fast/model-correctness.test.ts
+++ b/suite/src/__tests__/fast/model-correctness.test.ts
@@ -36,12 +36,8 @@ describe('Model Integration Test', () => {
     )
     await ceramicNode1.admin.startIndexingModels([model.id])
     await ceramicNode2.admin.startIndexingModels([model.id])
-    await waitForIndexingOrTimeout(
-      ceramicNode1,
-      ceramicNode2,
-      modelId,
-      1000 * 60 * indexWaitTimeMin,
-    )
+    await waitForIndexingOrTimeout(ceramicNode1, modelId, 1000 * 60 * indexWaitTimeMin)
+    await waitForIndexingOrTimeout(ceramicNode2, modelId, 1000 * 60 * indexWaitTimeMin)
     modelId = model.id
   })
 

--- a/suite/src/__tests__/fast/model-correctness.test.ts
+++ b/suite/src/__tests__/fast/model-correctness.test.ts
@@ -8,6 +8,7 @@ import { newModel, basicModelDocumentContent } from '../../models/modelConstants
 import { CeramicClient } from '@ceramicnetwork/http-client'
 import { CommonTestUtils as TestUtils } from '@ceramicnetwork/common-test-utils'
 import { utilities } from '../../utils/common.js'
+import { loadDocumentOrTimeout } from '../../utils/composeDbHelpers.js'
 
 const delay = utilities.delay
 const ComposeDbUrls = String(process.env.COMPOSEDB_URLS).split(',')
@@ -40,6 +41,14 @@ describe('Model Integration Test', () => {
   })
 
   test('Create a ModelInstanceDocument on one node and read it from another', async () => {
+    const isIndexed = await TestUtils.waitForConditionOrTimeout(async () => {
+      const indexedModels1 = await ceramicNode1.admin.getIndexedModels();
+      const indexedModels2 = await ceramicNode2.admin.getIndexedModels();
+      return indexedModels1.includes(modelId) && indexedModels2.includes(modelId);
+    }, 1000 * 60 * nodeSyncWaitTimeSec); // 3 minute timeout in millseconds
+    if (!isIndexed) {
+      throw new Error('Timeout reached: Failed to index the model')
+    }
     const modelInstanceDocumentMetadata = { model: modelId }
     const document1 = await ModelInstanceDocument.create(
       ceramicNode1,
@@ -48,7 +57,7 @@ describe('Model Integration Test', () => {
     )
     // We have to wait for some time for sync to happen
     await delay(nodeSyncWaitTimeSec)
-    const document2 = await ModelInstanceDocument.load(ceramicNode2, document1.id)
+    const document2 = await loadDocumentOrTimeout(ceramicNode2, document1.id, 1000 * nodeSyncWaitTimeSec)
     expect(document2.id).toEqual(document1.id)
   })
 })

--- a/suite/src/__tests__/fast/model-correctness.test.ts
+++ b/suite/src/__tests__/fast/model-correctness.test.ts
@@ -36,9 +36,9 @@ describe('Model Integration Test', () => {
     )
     await ceramicNode1.admin.startIndexingModels([model.id])
     await ceramicNode2.admin.startIndexingModels([model.id])
+    modelId = model.id
     await waitForIndexingOrTimeout(ceramicNode1, modelId, 1000 * 60 * indexWaitTimeMin)
     await waitForIndexingOrTimeout(ceramicNode2, modelId, 1000 * 60 * indexWaitTimeMin)
-    modelId = model.id
   })
 
   test('Create a ModelInstanceDocument on one node and read it from another', async () => {

--- a/suite/src/utils/common.ts
+++ b/suite/src/utils/common.ts
@@ -33,6 +33,8 @@ export const utilities = {
   },
   delay: async (seconds: number): Promise<void> =>
     new Promise((resolve) => setTimeout(() => resolve(), seconds * 1000)),
+  delayMs: async (ms: number): Promise<void> =>
+    new Promise((resolve) => setTimeout(() => resolve(), ms)),
 }
 
 export class EventAccumulator<T> {

--- a/suite/src/utils/composeDbHelpers.ts
+++ b/suite/src/utils/composeDbHelpers.ts
@@ -1,5 +1,8 @@
 import { ComposeClient } from '@composedb/client'
 import { utilities } from './common'
+import { CeramicClient } from '@ceramicnetwork/http-client'
+import { ModelInstanceDocument } from '@ceramicnetwork/model-instance-document'
+import { StreamID } from '@ceramicnetwork/streamid'
 
 const delay = utilities.delay
 
@@ -35,5 +38,21 @@ export async function waitForDocument(
       throw new Error('Timeout waiting for document')
     }
     await delay(1)
+  }
+}
+
+export async function loadDocumentOrTimeout(ceramicNode: CeramicClient, documentId: StreamID, timeoutMs: number) {
+  const startTime = Date.now()
+  while (true) {
+    try {
+      const doc = await ModelInstanceDocument.load(ceramicNode, documentId);
+      return doc; 
+    } catch (error) {
+      console.log(`Error loading document : ${documentId} retrying`, error)
+      if (Date.now() - startTime > timeoutMs) {
+        throw new Error('Timeout waiting for document')
+      }
+      await delay(1)
+    }
   }
 }

--- a/suite/src/utils/composeDbHelpers.ts
+++ b/suite/src/utils/composeDbHelpers.ts
@@ -88,6 +88,14 @@ export async function waitForIndexingOrTimeout(
   while (now < expirationTime) {
     const indexedModels1 = await ceramicNode1.admin.getIndexedModels()
     const indexedModels2 = await ceramicNode2.admin.getIndexedModels()
+    console.log(
+      'Indexed models on node1',
+      indexedModels1.map((m) => m.toString()),
+    )
+    console.log(
+      'Indexed models on node2',
+      indexedModels2.map((m) => m.toString()),
+    )
     if (indexedModels1.includes(modelId) && indexedModels2.includes(modelId)) {
       return true
     }

--- a/suite/src/utils/composeDbHelpers.ts
+++ b/suite/src/utils/composeDbHelpers.ts
@@ -89,14 +89,12 @@ async function isModelIndexed(ceramicNode: CeramicClient, modelId: StreamID): Pr
 /**
  * Waits for indexing to complete on both nodes or a timeout.
  * @param ceramicNode1 : Ceramic client to check indexing on
- * @param ceramicNode2 : Ceramic client to check indexing on
  * @param modelId : ID of the model to check indexing for
  * @param timeoutMs : Timeout in milliseconds
- * @returns True if indexing is complete on both nodes, throws error on timeout
+ * @returns True if indexing is complete, throws error on timeout
  */
 export async function waitForIndexingOrTimeout(
-  ceramicNode1: CeramicClient,
-  ceramicNode2: CeramicClient,
+  ceramicNode: CeramicClient,
   modelId: StreamID,
   timeoutMs: number,
 ): Promise<boolean> {
@@ -104,10 +102,9 @@ export async function waitForIndexingOrTimeout(
   const expirationTime = startTime + timeoutMs
 
   while (Date.now() < expirationTime) {
-    const isIndexedOnNode1 = await isModelIndexed(ceramicNode1, modelId)
-    const isIndexedOnNode2 = await isModelIndexed(ceramicNode2, modelId)
+    const isIndexedOnNode1 = await isModelIndexed(ceramicNode, modelId)
 
-    if (isIndexedOnNode1 && isIndexedOnNode2) {
+    if (isIndexedOnNode1) {
       return true
     }
 

--- a/suite/src/utils/composeDbHelpers.ts
+++ b/suite/src/utils/composeDbHelpers.ts
@@ -1,7 +1,7 @@
 import { ComposeClient } from '@composedb/client'
 import { utilities } from './common'
 import { CeramicClient } from '@ceramicnetwork/http-client'
-import { ModelInstanceDocument } from '@ceramicnetwork/model-instance-document'
+import { ModelInstanceDocument } from '@ceramicnetwork/stream-model-instance'
 import { StreamID } from '@ceramicnetwork/streamid'
 
 const delay = utilities.delay
@@ -41,6 +41,13 @@ export async function waitForDocument(
   }
 }
 
+/**
+ * Loads a document from a ceramic node with a timeout.
+ * @param ceramicNode : Ceramic client to load teh document from
+ * @param documentId : ID of the document to load
+ * @param timeoutMs : Timeout in milliseconds
+ * @returns 
+ */
 export async function loadDocumentOrTimeout(ceramicNode: CeramicClient, documentId: StreamID, timeoutMs: number) {
   const startTime = Date.now()
   while (true) {

--- a/suite/src/utils/composeDbHelpers.ts
+++ b/suite/src/utils/composeDbHelpers.ts
@@ -5,6 +5,7 @@ import { ModelInstanceDocument } from '@ceramicnetwork/stream-model-instance'
 import { StreamID } from '@ceramicnetwork/streamid'
 
 const delay = utilities.delay
+const delayMs = utilities.delayMs
 
 /**
  * Waits for a specific document to be available by repeatedly querying the ComposeDB until the document is found or a timeout occurs.
@@ -61,7 +62,7 @@ export async function loadDocumentOrTimeout(
       return doc
     } catch (error) {
       console.log(`Error loading document : ${documentId} retrying`, error)
-      await delay(10)
+      await delayMs(10)
       now = Date.now()
     }
   }
@@ -90,11 +91,9 @@ export async function waitForIndexingOrTimeout(
     if (indexedModels1.includes(modelId) && indexedModels2.includes(modelId)) {
       return true
     }
-    await delay(100)
+    await delayMs(100)
     now = Date.now()
-    console.log(
-      `Waiting for indexing model: ${modelId}, indexed on node1: ${indexedModels1.toString()}, indexed on node2: ${indexedModels2.toString()}`,
-    )
+    console.log(`Waiting for indexing model: ${modelId} on both ceramic nodes`)
   }
   throw Error(`Timeout waiting for indexing model: ${modelId}`)
 }

--- a/suite/src/utils/composeDbHelpers.ts
+++ b/suite/src/utils/composeDbHelpers.ts
@@ -90,11 +90,11 @@ export async function waitForIndexingOrTimeout(
     const indexedModels2 = await ceramicNode2.admin.getIndexedModels()
     console.log(
       'Indexed models on node1',
-      indexedModels1.map((m) => m.toString()),
+      indexedModels1.map((m) => m.baseID.toString()),
     )
     console.log(
       'Indexed models on node2',
-      indexedModels2.map((m) => m.toString()),
+      indexedModels2.map((m) => m.baseID.toString()),
     )
     if (indexedModels1.includes(modelId) && indexedModels2.includes(modelId)) {
       return true


### PR DESCRIPTION
This test was failing intermittently with an error of 'Error message : 'Internal Server Error': ***"error":"block was not found locally (offline)'
This error was being thrown from line : https://github.com/ceramicnetwork/js-ceramic/blob/51369364bfe9f6b63eac2af500f7427d476d7430/packages/core/src/state-management/repository.ts#L245. 
Thus if we wait for the model to be indexed and synced, this test would become more robust.

Discord thread link for investigations : https://discord.com/channels/484729862368526356/1215688378213867530/1238527178115780709