### PR TITLE
feat: Add test case for writing event with invalid metadata

### DIFF
--- a/suite/src/__tests__/fast/get-events.test.ts
+++ b/suite/src/__tests__/fast/get-events.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from '@jest/globals'
 import fetch from 'cross-fetch'
-import { ReconEventInput, generateRandomEvent } from '../../utils/rustCeramicHelpers'
+import {
+  ReconEventInput,
+  generateRandomEvent,
+  generateRandomRawEvent,
+  encodeRawEvent,
+} from '../../utils/rustCeramicHelpers'
 import { StreamID, randomCID } from '@ceramicnetwork/streamid'
 
 const CeramicUrls = String(process.env.CERAMIC_URLS).split(',')
@@ -22,7 +27,10 @@ async function postEvent(url: string, event: ReconEventInput) {
     body: JSON.stringify(event),
   })
   if (!response.ok) {
-    throw new Error(`HTTP error! status: ${response.status} ${response.statusText}`)
+    const message = await response.text()
+    throw new Error(
+      `Error posting event data to C1: ${response.status} ${response.statusText}: ${message}`,
+    )
   }
 }
 
@@ -37,6 +45,18 @@ describe('rust-ceramic e2e test', () => {
     const getResponse = await getEventData(ceramicUrl, event.id)
     expect(getResponse.status).toEqual(200)
     expect(await getResponse.json()).toEqual(event)
+  })
+
+  test('Cannot store event with unexpected metadata', async () => {
+    const modelId = new StreamID('model', randomCID())
+    const rawEvent = generateRandomRawEvent(modelId, 'did:key:faketestcontroller')
+    rawEvent.header.unexpected = "this field isn't a valid metadata field!"
+
+    const event = encodeRawEvent(rawEvent)
+    // publishing the event to rust-ceramic
+    await expect(postEvent(ceramicUrl, { data: event.data })).rejects.toThrow(
+      /Event bytes do not round-trip. This most likely means the event contains unexpected fields./,
+    )
   })
 
   test('get event data for non-existing event', async () => {

--- a/suite/src/utils/rustCeramicHelpers.ts
+++ b/suite/src/utils/rustCeramicHelpers.ts
@@ -3,7 +3,7 @@ import { CARFactory } from 'cartonne'
 import * as dagJson from '@ipld/dag-json'
 import * as dagCbor from '@ipld/dag-cbor'
 import { sha256 } from 'multihashes-sync/sha2'
-import { GenesisHeader, GenesisCommit } from '@ceramicnetwork/common'
+import { GenesisCommit, GenesisHeader } from '@ceramicnetwork/common'
 import { randomBytes } from 'crypto'
 
 export interface ReconEventInput {
@@ -16,11 +16,7 @@ export interface ReconEvent {
   data: string // car file
 }
 
-export function generateRandomEvent(modelId: StreamID, controller: string): ReconEvent {
-  const carFactory = new CARFactory()
-  carFactory.codecs.add(dagJson)
-  carFactory.hashers.add(sha256)
-  const car = carFactory.build().asV1()
+export function generateRandomRawEvent(modelId: StreamID, controller: string): GenesisCommit {
   const header: GenesisHeader = {
     controllers: [controller],
     model: modelId.bytes,
@@ -28,10 +24,17 @@ export function generateRandomEvent(modelId: StreamID, controller: string): Reco
     // make the events different so they don't get deduped. is this spec compliant?
     unique: randomBytes(12),
   }
-  const commit: GenesisCommit = {
+  return {
     header,
     data: null, // deterministic commit has no data and requires no signature
   }
+}
+
+export function encodeRawEvent(commit: GenesisCommit): ReconEvent {
+  const carFactory = new CARFactory()
+  carFactory.codecs.add(dagJson)
+  carFactory.hashers.add(sha256)
+  const car = carFactory.build().asV1()
   dagCbor.encode(commit)
   car.put(commit, { isRoot: true })
   const cid = car.roots[0]
@@ -39,6 +42,11 @@ export function generateRandomEvent(modelId: StreamID, controller: string): Reco
     data: car.toString('base64'),
     id: cid.toString(),
   }
+}
+
+export function generateRandomEvent(modelId: StreamID, controller: string): ReconEvent {
+  const commit = generateRandomRawEvent(modelId, controller)
+  return encodeRawEvent(commit)
 }
 
 export function randomEvents(modelID: StreamID, count: number): ReconEvent[] {


### PR DESCRIPTION
this test will fail for now, until https://linear.app/3boxlabs/issue/WS1-1633/disallow-unexpected-metadata-fields-in-events is implemented.