### PR TITLE
feat: Restore test coverage of updates

### DIFF
--- a/suite/src/__tests__/fast/model-correctness.test.ts
+++ b/suite/src/__tests__/fast/model-correctness.test.ts
@@ -4,7 +4,7 @@ import { createDid } from '../../utils/didHelper.js'
 import { StreamID } from '@ceramicnetwork/streamid'
 import { Model } from '@ceramicnetwork/stream-model'
 import { ModelInstanceDocument } from '@ceramicnetwork/stream-model-instance'
-import { newModel, basicModelDocumentContent } from '../../models/modelConstants'
+import { newModel } from '../../models/modelConstants'
 import { CeramicClient } from '@ceramicnetwork/http-client'
 import { CommonTestUtils as TestUtils } from '@ceramicnetwork/common-test-utils'
 import { loadDocumentOrTimeout, waitForIndexingOrTimeout } from '../../utils/composeDbHelpers.js'
@@ -41,12 +41,13 @@ describe('Model Integration Test', () => {
     await waitForIndexingOrTimeout(ceramicNode2, modelId, 1000 * 60 * indexWaitTimeMin)
   })
 
-  test('Create a ModelInstanceDocument on one node and read it from another', async () => {
+  test('ModelInstanceDocuments sync between nodes', async () => {
     const modelInstanceDocumentMetadata = { model: modelId }
     const document1 = await ModelInstanceDocument.create(
       ceramicNode1,
-      basicModelDocumentContent,
+      { myData: 1 },
       modelInstanceDocumentMetadata,
+      { anchor: false },
     )
     const document2 = await loadDocumentOrTimeout(
       ceramicNode2,
@@ -54,5 +55,16 @@ describe('Model Integration Test', () => {
       1000 * nodeSyncWaitTimeSec,
     )
     expect(document2.id).toEqual(document1.id)
+    expect(document1.content).toEqual(document2.content)
+
+    // Now update on the second node and ensure update syncs back to the first node.
+    await document2.replace({ myData: 2 }, null, { anchor: false })
+    await TestUtils.waitForConditionOrTimeout(async () => {
+      await document1.sync()
+      return document1.content?.myData == 2
+    })
+    expect(document1.content).toEqual(document2.content)
+    expect(document1.state.log.length).toEqual(2)
+    expect(document2.state.log.length).toEqual(2)
   })
 })

--- a/suite/src/__tests__/fast/model-correctness.test.ts
+++ b/suite/src/__tests__/fast/model-correctness.test.ts
@@ -7,12 +7,11 @@ import { ModelInstanceDocument } from '@ceramicnetwork/stream-model-instance'
 import { newModel } from '../../models/modelConstants'
 import { CeramicClient } from '@ceramicnetwork/http-client'
 import { CommonTestUtils as TestUtils } from '@ceramicnetwork/common-test-utils'
-import { loadDocumentOrTimeout, waitForIndexingOrTimeout } from '../../utils/composeDbHelpers.js'
+import { indexModelOnNode, loadDocumentOrTimeout } from '../../utils/composeDbHelpers.js'
 
 const ComposeDbUrls = String(process.env.COMPOSEDB_URLS).split(',')
 const adminSeeds = String(process.env.COMPOSEDB_ADMIN_DID_SEEDS).split(',')
 const nodeSyncWaitTimeSec = 5
-const indexWaitTimeMin = 1
 
 describe('Model Integration Test', () => {
   let ceramicNode1: CeramicClient
@@ -28,24 +27,17 @@ describe('Model Integration Test', () => {
     ceramicNode1 = await newCeramic(ComposeDbUrls[0], did1)
     ceramicNode2 = await newCeramic(ComposeDbUrls[1], did2)
     const model = await Model.create(ceramicNode1, newModel)
-    await TestUtils.waitForConditionOrTimeout(async () =>
-      ceramicNode2
-        .loadStream(model.id)
-        .then((_) => true)
-        .catch((_) => false),
-    )
-    await ceramicNode1.admin.startIndexingModels([model.id])
-    await ceramicNode2.admin.startIndexingModels([model.id])
     modelId = model.id
-    await waitForIndexingOrTimeout(ceramicNode1, modelId, 1000 * 60 * indexWaitTimeMin)
-    await waitForIndexingOrTimeout(ceramicNode2, modelId, 1000 * 60 * indexWaitTimeMin)
+
+    await indexModelOnNode(ceramicNode1, model.id)
+    await indexModelOnNode(ceramicNode2, model.id)
   })
 
   test('ModelInstanceDocuments sync between nodes', async () => {
     const modelInstanceDocumentMetadata = { model: modelId }
     const document1 = await ModelInstanceDocument.create(
       ceramicNode1,
-      { myData: 1 },
+      { step: 1 },
       modelInstanceDocumentMetadata,
       { anchor: false },
     )
@@ -58,10 +50,10 @@ describe('Model Integration Test', () => {
     expect(document1.content).toEqual(document2.content)
 
     // Now update on the second node and ensure update syncs back to the first node.
-    await document2.replace({ myData: 2 }, null, { anchor: false })
+    await document2.replace({ step: 2 }, null, { anchor: false })
     await TestUtils.waitForConditionOrTimeout(async () => {
       await document1.sync()
-      return document1.content?.myData == 2
+      return document1.content?.step == 2
     })
     expect(document1.content).toEqual(document2.content)
     expect(document1.state.log.length).toEqual(2)

--- a/suite/src/models/modelConstants.ts
+++ b/suite/src/models/modelConstants.ts
@@ -7,7 +7,7 @@ export const newModel: ModelDefinition = {
     type: 'object',
     additionalProperties: false,
     properties: {
-      myData: {
+      step: {
         type: 'integer',
         minimum: 0,
         maximum: 10000,

--- a/suite/src/models/modelConstants.ts
+++ b/suite/src/models/modelConstants.ts
@@ -18,7 +18,3 @@ export const newModel: ModelDefinition = {
     type: 'list',
   },
 }
-
-export const basicModelDocumentContent = {
-  myData: 2,
-}

--- a/suite/src/utils/composeDbHelpers.ts
+++ b/suite/src/utils/composeDbHelpers.ts
@@ -1,8 +1,9 @@
 import { ComposeClient } from '@composedb/client'
-import { utilities } from './common'
+import { utilities } from './common.js'
 import { CeramicClient } from '@ceramicnetwork/http-client'
 import { ModelInstanceDocument } from '@ceramicnetwork/stream-model-instance'
 import { StreamID } from '@ceramicnetwork/streamid'
+import { CommonTestUtils as TestUtils } from '@ceramicnetwork/common-test-utils'
 
 const delay = utilities.delay
 const delayMs = utilities.delayMs
@@ -113,4 +114,19 @@ export async function waitForIndexingOrTimeout(
   }
 
   throw new Error(`Timeout waiting for indexing model: ${modelId}`)
+}
+
+export async function indexModelOnNode(
+  node: CeramicClient,
+  modelId: StreamID,
+  timeoutMs = 1000 * 10,
+): Promise<void> {
+  await TestUtils.waitForConditionOrTimeout(async () =>
+    node
+      .loadStream(modelId)
+      .then((_) => true)
+      .catch((_) => false),
+  )
+  await node.admin.startIndexingModels([modelId])
+  await waitForIndexingOrTimeout(node, modelId, timeoutMs)
 }


### PR DESCRIPTION
The fact that the update test has been skipped for so long, means that the anchor and longevity tests have also effectively been skipped as well since they'll never find any documents in the database to test against.

This PR makes several changes:
- Adds updates to the explicit model-correctness.test.ts
- Re-enables update.test.ts after switching it to use MIDs instead of TileDocuments
- Updates anchor.test.ts and longevity.test.ts to work with streams in the database that are either TileDocuments OR ModelInstanceDocuments.