### PR TITLE
chore: Poll for data to sync instead of sleeping

### DIFF
--- a/suite/src/__tests__/fast/composedb-model-sync.test.ts
+++ b/suite/src/__tests__/fast/composedb-model-sync.test.ts
@@ -1,12 +1,11 @@
 import { ComposeClient } from '@composedb/client'
 import { beforeAll, describe, test, expect } from '@jest/globals'
 import { Composite } from '@composedb/devtools'
-import { newCeramic } from '../../utils/ceramicHelpers.js'
+import { loadDocumentOrTimeout, newCeramic } from '../../utils/ceramicHelpers.js'
 import { createDid } from '../../utils/didHelper.js'
 import { BasicSchema } from '../../graphql-schemas/basicSchema'
 import { StreamID } from '@ceramicnetwork/streamid'
 import { waitForDocument } from '../../utils/composeDbHelpers.js'
-import { CommonTestUtils as TestUtils } from '@ceramicnetwork/common-test-utils'
 
 const ComposeDbUrls = String(process.env.COMPOSEDB_URLS).split(',')
 const adminSeeds = String(process.env.COMPOSEDB_ADMIN_DID_SEEDS).split(',')
@@ -40,14 +39,10 @@ describe('Sync Model and ModelInstanceDocument using ComposeDB GraphQL API', () 
     const parts = String(resources[0]).split('model=')
     const modelId = parts[parts.length - 1]
 
-    await TestUtils.waitForConditionOrTimeout(async () =>
-      ceramicInstance2
-        .loadStream(modelId)
-        .then((_) => true)
-        .catch((_) => false),
-    )
+    // Wait for model to be available on node 2.
+    await loadDocumentOrTimeout(ceramicInstance2, StreamID.fromString(modelId), 30 * 1000)
 
-    // start indexing for tha nodel on node 2
+    // start indexing for the model on node 2
     await ceramicInstance2.admin.startIndexingModels([StreamID.fromString(modelId)])
     composeClient2 = await new ComposeClient({
       ceramic: ceramicInstance2,

--- a/suite/src/__tests__/fast/model-correctness.test.ts
+++ b/suite/src/__tests__/fast/model-correctness.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, beforeAll, expect } from '@jest/globals'
-import { newCeramic } from '../../utils/ceramicHelpers.js'
+import { loadDocumentOrTimeout, newCeramic } from '../../utils/ceramicHelpers.js'
 import { createDid } from '../../utils/didHelper.js'
 import { StreamID } from '@ceramicnetwork/streamid'
 import { Model } from '@ceramicnetwork/stream-model'
@@ -7,7 +7,7 @@ import { ModelInstanceDocument } from '@ceramicnetwork/stream-model-instance'
 import { LIST_MODEL_DEFINITION } from '../../models/modelConstants'
 import { CeramicClient } from '@ceramicnetwork/http-client'
 import { CommonTestUtils as TestUtils } from '@ceramicnetwork/common-test-utils'
-import { indexModelOnNode, loadDocumentOrTimeout } from '../../utils/composeDbHelpers.js'
+import { indexModelOnNode } from '../../utils/composeDbHelpers.js'
 
 const ComposeDbUrls = String(process.env.COMPOSEDB_URLS).split(',')
 const adminSeeds = String(process.env.COMPOSEDB_ADMIN_DID_SEEDS).split(',')
@@ -41,11 +41,11 @@ describe('Model Integration Test', () => {
       modelInstanceDocumentMetadata,
       { anchor: false },
     )
-    const document2 = await loadDocumentOrTimeout(
+    const document2 = (await loadDocumentOrTimeout(
       ceramicNode2,
       document1.id,
       1000 * nodeSyncWaitTimeSec,
-    )
+    )) as ModelInstanceDocument
     expect(document2.id).toEqual(document1.id)
     expect(document1.content).toEqual(document2.content)
 

--- a/suite/src/__tests__/slow/ceramic-ceramic-integration.test.ts
+++ b/suite/src/__tests__/slow/ceramic-ceramic-integration.test.ts
@@ -3,7 +3,7 @@ import { TileDocument } from '@ceramicnetwork/stream-tile'
 import { jest, describe, test, beforeAll, expect } from '@jest/globals'
 import { newCeramic, waitForAnchor, waitForCondition } from '../../utils/ceramicHelpers.js'
 
-const UPDATE_TIMEOUT = 60 // 60 seconds for regular updates to propagate from one node to another
+const UPDATE_TIMEOUT_MS = 60 * 1000 // 60 seconds for regular updates to propagate from one node to another
 const ComposeDbUrls = String(process.env.COMPOSEDB_URLS).split(',')
 
 const createWithOneLoadWithTheOther = async (
@@ -53,7 +53,7 @@ const updatesAreShared = async (
     function (state) {
       return state.next?.content.foo == content1.foo || state.content.foo == content1.foo
     },
-    UPDATE_TIMEOUT,
+    UPDATE_TIMEOUT_MS,
   ).catch((errStr) => {
     throw new Error(errStr)
   })
@@ -74,7 +74,7 @@ const updatesAreShared = async (
     function (state) {
       return state.next?.content.foo == content2.foo || state.content.foo == content2.foo
     },
-    UPDATE_TIMEOUT,
+    UPDATE_TIMEOUT_MS,
   )
 
   expect(doc2.content).toEqual(content2)

--- a/suite/src/utils/composeDbHelpers.ts
+++ b/suite/src/utils/composeDbHelpers.ts
@@ -1,7 +1,6 @@
 import { ComposeClient } from '@composedb/client'
 import { utilities } from './common.js'
 import { CeramicClient } from '@ceramicnetwork/http-client'
-import { ModelInstanceDocument } from '@ceramicnetwork/stream-model-instance'
 import { StreamID } from '@ceramicnetwork/streamid'
 import { CommonTestUtils as TestUtils } from '@ceramicnetwork/common-test-utils'
 
@@ -44,40 +43,6 @@ export async function waitForDocument(
 }
 
 /**
- * Loads a document from a ceramic node with a timeout.
- * @param ceramicNode : Ceramic client to load the document from
- * @param documentId : ID of the document to load
- * @param timeoutMs : Timeout in milliseconds
- * @returns The document if found, throws error on timeout
- */
-export async function loadDocumentOrTimeout(
-  ceramicNode: CeramicClient,
-  documentId: StreamID,
-  timeoutMs: number,
-) {
-  let now = Date.now()
-  let count = 0
-  const expirationTime = now + timeoutMs
-  let lastError = null
-  while (now < expirationTime) {
-    try {
-      count += 1
-      return await ModelInstanceDocument.load(ceramicNode, documentId)
-    } catch (error) {
-      lastError = error
-      if (count % 10 === 0) {
-        console.log(`Error loading document : ${documentId} retrying`, error)
-      }
-      await delayMs(100)
-      now = Date.now()
-    }
-  }
-  throw Error(
-    `Timeout waiting for document ${documentId}. Last seen error when trying to load it: ${lastError}`,
-  )
-}
-
-/**
  * Checks if a model is indexed on a Ceramic node.
  * @param ceramicNode : Ceramic client to check indexing on
  * @param modelId : ID of the model to check indexing for
@@ -96,7 +61,7 @@ async function isModelIndexed(ceramicNode: CeramicClient, modelId: StreamID): Pr
 
 /**
  * Waits for indexing to complete on both nodes or a timeout.
- * @param ceramicNode1 : Ceramic client to check indexing on
+ * @param ceramicNode : Ceramic client to check indexing on
  * @param modelId : ID of the model to check indexing for
  * @param timeoutMs : Timeout in milliseconds
  * @returns True if indexing is complete, throws error on timeout


### PR DESCRIPTION
No real functional change, doesn't change any of the timeouts, just switches strategy from waiting a fixed time and then expecting the data to have synced to polling to see if the data has been synced instead.  Wanted to isolate this change from any changes that actually increase the timeout, which will come next.