### PR TITLE
fix: increase sync timeout

### DIFF
--- a/suite/src/__tests__/fast/composedb-model-sync.test.ts
+++ b/suite/src/__tests__/fast/composedb-model-sync.test.ts
@@ -9,7 +9,7 @@ import { waitForDocument } from '../../utils/composeDbHelpers.js'
 
 const ComposeDbUrls = String(process.env.COMPOSEDB_URLS).split(',')
 const adminSeeds = String(process.env.COMPOSEDB_ADMIN_DID_SEEDS).split(',')
-const timeoutMs = 60000
+const SYNC_TIMEOUT_MS = 60 * 1000
 
 describe('Sync Model and ModelInstanceDocument using ComposeDB GraphQL API', () => {
   let composeClient1: ComposeClient
@@ -40,7 +40,7 @@ describe('Sync Model and ModelInstanceDocument using ComposeDB GraphQL API', () 
     const modelId = parts[parts.length - 1]
 
     // Wait for model to be available on node 2.
-    await loadDocumentOrTimeout(ceramicInstance2, StreamID.fromString(modelId), 30 * 1000)
+    await loadDocumentOrTimeout(ceramicInstance2, StreamID.fromString(modelId), SYNC_TIMEOUT_MS)
 
     // start indexing for the model on node 2
     await ceramicInstance2.admin.startIndexingModels([StreamID.fromString(modelId)])
@@ -98,7 +98,7 @@ describe('Sync Model and ModelInstanceDocument using ComposeDB GraphQL API', () 
       composeClient2,
       getDocumentByStreamIdQuery,
       getDocumentByStreamIdVariables,
-      timeoutMs,
+      SYNC_TIMEOUT_MS,
     )
     const queryResponseObj = JSON.parse(JSON.stringify(queryResponse))
     const queryResponseid = queryResponseObj?.data?.node?.id

--- a/suite/src/__tests__/fast/model-correctness.test.ts
+++ b/suite/src/__tests__/fast/model-correctness.test.ts
@@ -11,7 +11,7 @@ import { indexModelOnNode } from '../../utils/composeDbHelpers.js'
 
 const ComposeDbUrls = String(process.env.COMPOSEDB_URLS).split(',')
 const adminSeeds = String(process.env.COMPOSEDB_ADMIN_DID_SEEDS).split(',')
-const nodeSyncWaitTimeSec = 5
+const SYNC_TIMEOUT_MS = 30 * 1000
 
 describe('Model Integration Test', () => {
   let ceramicNode1: CeramicClient
@@ -44,7 +44,7 @@ describe('Model Integration Test', () => {
     const document2 = (await loadDocumentOrTimeout(
       ceramicNode2,
       document1.id,
-      1000 * nodeSyncWaitTimeSec,
+      SYNC_TIMEOUT_MS,
     )) as ModelInstanceDocument
     expect(document2.id).toEqual(document1.id)
     expect(document1.content).toEqual(document2.content)

--- a/suite/src/__tests__/fast/update.test.ts
+++ b/suite/src/__tests__/fast/update.test.ts
@@ -14,7 +14,7 @@ import { ModelInstanceDocument } from '@ceramicnetwork/stream-model-instance'
 // Environment variables
 const composeDbUrls = String(process.env.COMPOSEDB_URLS).split(',')
 const adminSeeds = String(process.env.COMPOSEDB_ADMIN_DID_SEEDS).split(',')
-const SYNC_TIMEOUT_MS = 5 * 1000 // 5 seconds
+const SYNC_TIMEOUT_MS = 30 * 1000 // 30 seconds
 
 ///////////////////////////////////////////////////////////////////////////////
 /// Create/Update Tests


### PR DESCRIPTION
Hope is that this will get the QA durable tests passing long enough to hold us over until the RedTree lands and improves the sync time here.