### PR TITLE
feat: run performance workflow

### DIFF
--- a/.github/workflows/run-performance.yaml
+++ b/.github/workflows/run-performance.yaml
@@ -5,7 +5,7 @@ on:
     inputs:
       test_name:
         type: string
-        description: Folder name containing the performance test yaml
+        description: Folder name under "performance" that contains yaml
         required: true
       js_ceramic_image:
         type: string
@@ -29,14 +29,22 @@ env:
   RUSTC_WRAPPER: "sccache"
 
 jobs:
-  template-network:
-    name: Template Network
+  run-performance-test:
+    name: Run Performance Test ${{ github.run_id }}
     runs-on: ubuntu-latest
+    environment: cas-scaling-2024
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Install jq
-        run: sudo apt-get install jq
+
+      - name: Install yq
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y software-properties-common
+          sudo add-apt-repository -y ppa:rmescandon/yq
+          sudo apt-get update
+          sudo apt-get install -y yq
+
       - name: Template network
         run: |
           set -exo pipefail
@@ -44,5 +52,84 @@ jobs:
           export SCENARIO_IMAGE=${{ inputs.scenario_image }}
           export JS_CERAMIC_IMAGE=${{ inputs.js_ceramic_image }}
           export TEST_NAME=${{ inputs.test_name }}
-          ls -l tests/performance/$TEST_NAME.yaml
+          ls -l performance/$TEST_NAME
+          export THIS_TEST=${{ inputs.test_name }}-${{ github.run_id }}
+          mkdir -p performance/$THIS_TEST
+          # set the network name yaml key to the test names
+          yq e '.metadata.name = env(THIS_TEST)' performance/$TEST_NAME/network.yaml \
+            > performance/$THIS_TEST/network.yaml
+          cat performance/$THIS_TEST/network.yaml
+          echo "THIS_TEST=$THIS_TEST" >> $GITHUB_ENV
+          echo "THIS_TEST_NAMESPACE=keramik-${THIS_TEST}" >> $GITHUB_ENV
+          echo "TEST_NAME=${TEST_NAME}" >> $GITHUB_ENV
 
+      - name: Setup GKE auth
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: ${{ secrets.GKE_SA_KEY }}
+
+      - name: Get GKE credentials
+        uses: 'google-github-actions/get-gke-credentials@v1'
+        with:
+          cluster_name: ${{ vars.GKE_CLUSTER }}
+          location: ${{ vars.GKE_ZONE }}
+
+      - name: Deploy network
+        run: |
+          kubectl apply -f performance/$THIS_TEST/network.yaml
+
+      - name: Wait for bootstrap to complete
+        timeout-minutes: 8
+        run: |
+          set -exo pipefail
+          sleep 60
+          kubectl wait --for=condition=ready \
+            --timeout=240s \
+            pod \
+            -l app=ceramic \
+            -n ${THIS_TEST_NAMESPACE}
+          sleep 60
+          kubectl wait --for=condition=complete \
+            --timeout=120s \
+            job/bootstrap \
+            -n ${THIS_TEST_NAMESPACE}
+
+      - name: Template simulation
+        run: |
+          set -exo pipefail
+          yq e '.metadata.namespace = env(THIS_TEST_NAMESPACE)' performance/$TEST_NAME/simulation.yaml \
+            > performance/$THIS_TEST/simulation.yaml
+          cat performance/$THIS_TEST/simulation.yaml
+
+      - name: Run simulation
+        run: |
+          set -exo pipefail
+          kubectl apply -f performance/$THIS_TEST/simulation.yaml
+          SIMULATION_RUNTIME=$(yq e '.spec.runTime' performance/$THIS_TEST/simulation.yaml)
+          echo "SIMULATION_RUNTIME=${SIMULATION_RUNTIME}" >> $GITHUB_ENV
+
+      - name: Notify Discord
+        env:
+          SIMULATION_COLOR: 3066993
+        run: |
+          set -exo pipefail
+          export SIMULATION_STATUS_TAG="Simulation $THIS_TEST started"
+          export CLUSTER_NAME=${{ vars.GKE_CLUSTER }}
+          envsubst < notifications/notification-template.json  > message.json
+          cat message.json
+          curl -v -H "Content-Type: application/json" -X POST -d @./message.json "${{ secrets.DISCORD_WEBHOOK_URL_SUCCEEDED }}"
+
+      - name: Wait for simulation to complete
+        run: |
+          set -exo pipefail
+          # runtime is in minutes
+          sleep $((${SIMULATION_RUNTIME} * 60))
+          kubectl wait --for=condition=complete \
+            --timeout=120s \
+            job/simulate-manager \
+            -n ${THIS_TEST_NAMESPACE}
+
+      - name: Cleanup
+        if: always()
+        run: |
+          kubectl delete -f performance/$THIS_TEST/network.yaml

--- a/.github/workflows/run-performance.yaml
+++ b/.github/workflows/run-performance.yaml
@@ -23,11 +23,6 @@ on:
         required: true
         default: public.ecr.aws/r5b3e0r5/3box/keramik-runner:latest
 
-env:
-  CARGO_TERM_COLOR: always
-  SCCACHE_GHA_ENABLED: "true"
-  RUSTC_WRAPPER: "sccache"
-
 jobs:
   run-performance-test:
     name: Run Performance Test ${{ github.run_id }}
@@ -61,6 +56,8 @@ jobs:
           # set the network name yaml key to the test names
           yq e '.metadata.name = env(THIS_TEST)' performance/$TEST_NAME/network.yaml \
             > performance/$THIS_TEST/network.yaml
+          yq e '.spec.ceramic[0].image = env(JS_CERAMIC_IMAGE)' -i performance/$THIS_TEST/network.yaml
+          yq e '.spec.ceramic[0].ipfs.rust.image = env(RUST_CERAMIC_IMAGE)' -i performance/$THIS_TEST/network.yaml
           cat performance/$THIS_TEST/network.yaml
           echo "THIS_TEST=$THIS_TEST" >> $GITHUB_ENV
           echo "THIS_TEST_NAMESPACE=keramik-${THIS_TEST}" >> $GITHUB_ENV

--- a/.github/workflows/run-performance.yaml
+++ b/.github/workflows/run-performance.yaml
@@ -39,11 +39,14 @@ jobs:
 
       - name: Install yq
         run: |
-          sudo apt-get update
-          sudo apt-get install -y software-properties-common
-          sudo add-apt-repository -y ppa:rmescandon/yq
-          sudo apt-get update
-          sudo apt-get install -y yq
+          # sudo apt-get update
+          # sudo apt-get install -y software-properties-common
+          # sudo add-apt-repository -y ppa:rmescandon/yq
+          # sudo apt-get update
+          # sudo apt-get install -y yq
+          curl -L https://github.com/mikefarah/yq/releases/download/v4.40.7/yq_linux_amd64 -o yq
+          chmod +x yq
+          sudo mv ./yq /usr/local/bin/yq
 
       - name: Template network
         run: |

--- a/notifications/notification-template.json
+++ b/notifications/notification-template.json
@@ -1,0 +1,20 @@
+{
+    "embeds": [
+      {
+        "title": "$SIMULATION_STATUS_TAG",
+        "description": "[Dashboard](https://threebox.grafana.net/d/adc2vf8f58idcd/keramik-simulation?orgId=1&var-cluster=${CLUSTER_NAME}&var-namespace=$THIS_TEST_NAMESPACE&from=now-1h&to=now) [Logs](https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Aresource.labels.cluster_name%3D%22${CLUSTER_NAME}%22%0Aresource.labels.namespace_name%3D%22${THIS_TEST_NAMESPACE}%22%0A;duration=PT1H?project=ceramic-perfomance-tests)",
+        "color": $SIMULATION_COLOR,
+        "fields": [
+          {
+            "name": "Duration",
+            "value": "$SIMULATION_RUNTIME",
+            "inline": true
+          },
+          {
+            "name": "Namespace",
+            "value": "$THIS_TEST_NAMESPACE"
+          }
+        ]
+      }
+    ]
+  }

--- a/performance/README.md
+++ b/performance/README.md
@@ -1,0 +1,23 @@
+# Performance tests
+
+## Running
+
+Each subdirectory contains a network.yaml and simulation.yaml defining a keramik test that is designed to be run through the Github Action [run-performance](./.github/workflows/run-performance.yaml).
+
+The test name is the directory name.
+
+To run a test, go to the ["Run Performance" Github Action](https://github.com/3box/ceramic-tests/actions/workflows/run-performance.yaml) and use the directory name for the "Folder name containing the performance test yaml" input.
+
+## Adding a new test
+
+To add a new test, create a new directory with a network.yaml and simulation.yaml.
+
+Ensure that the following setting are used to capture metrics.
+
+```
+spec:
+  monitoring:
+    namespaced: true
+    podMonitor:
+      enabled: true
+```

--- a/performance/ceramic-anchoring-benchmark/network.yaml
+++ b/performance/ceramic-anchoring-benchmark/network.yaml
@@ -31,6 +31,4 @@ spec:
   monitoring:
     namespaced: true
   replicas: 2
-  bootstrap:
-    image: samika98/runner:cabv1
-    imagePullPolicy: IfNotPresent
+

--- a/performance/ceramic-anchoring-benchmark/network.yaml
+++ b/performance/ceramic-anchoring-benchmark/network.yaml
@@ -1,0 +1,36 @@
+apiVersion: keramik.3box.io/v1alpha1
+kind: Network
+metadata:
+  name: ceramic-anchoring-benchmark
+spec:
+  ceramic:
+    - env:
+        CERAMIC_RECON_MODE: "true"
+      image: ceramicnetwork/js-ceramic:latest
+      imagePullPolicy: Always
+      ipfs:
+        rust:
+          env:
+            CERAMIC_ONE_RECON: "true"
+          resourceLimits:
+            cpu: "6"
+            memory: 6Gi
+          image: public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest
+          imagePullPolicy: Always
+      resourceLimits:
+        cpu: "4"
+        memory: 8Gi
+  casApiUrl: https://cas-dev-direct.3boxlabs.com
+  networkType: dev-unstable
+  ethRpcUrl: ""
+
+  datadog:
+    enabled: true
+    profilingEnabled: true
+    version: "0"
+  monitoring:
+    namespaced: true
+  replicas: 2
+  bootstrap:
+    image: samika98/runner:cabv1
+    imagePullPolicy: IfNotPresent

--- a/performance/ceramic-anchoring-benchmark/simulation.yaml
+++ b/performance/ceramic-anchoring-benchmark/simulation.yaml
@@ -10,5 +10,3 @@ spec:
   runTime: 20
   throttleRequests: 100
   anchorWaitTime: 40
-  image: samika98/runner:cab-v
-  imagePullPolicy: Always

--- a/performance/ceramic-anchoring-benchmark/simulation.yaml
+++ b/performance/ceramic-anchoring-benchmark/simulation.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: "keramik.3box.io/v1alpha1"
+kind: Simulation
+metadata:
+  name: ceramic-anchoring-benchmark
+  namespace: keramik-ceramic-benchmark
+spec:
+  scenario: ceramic-anchoring-benchmark
+  users: 16
+  runTime: 20
+  throttleRequests: 100
+  anchorWaitTime: 40
+  image: samika98/runner:cab-v
+  imagePullPolicy: Always

--- a/performance/ceramic-new-streams/network.yaml
+++ b/performance/ceramic-new-streams/network.yaml
@@ -6,7 +6,6 @@ spec:
   ceramic:
     - env:
         CERAMIC_RECON_MODE: "true"
-      image: ceramicnetwork/js-ceramic:latest
       imagePullPolicy: Always
       ipfs:
         rust:
@@ -15,7 +14,6 @@ spec:
           resourceLimits:
             cpu: "6"
             memory: 6Gi
-          image: public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest
           imagePullPolicy: Always
       resourceLimits:
         cpu: "4"

--- a/performance/ceramic-new-streams/network.yaml
+++ b/performance/ceramic-new-streams/network.yaml
@@ -1,0 +1,35 @@
+apiVersion: keramik.3box.io/v1alpha1
+kind: Network
+metadata:
+  name: ceramic-new-streams
+spec:
+  ceramic:
+    - env:
+        CERAMIC_RECON_MODE: "true"
+      image: ceramicnetwork/js-ceramic:latest
+      imagePullPolicy: Always
+      ipfs:
+        rust:
+          env:
+            CERAMIC_ONE_RECON: "true"
+          resourceLimits:
+            cpu: "6"
+            memory: 6Gi
+          image: public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest
+          imagePullPolicy: Always
+      resourceLimits:
+        cpu: "4"
+        memory: 8Gi
+  casApiUrl: https://cas-dev-direct.3boxlabs.com
+  networkType: dev-unstable
+  ethRpcUrl: ""
+
+  datadog:
+    enabled: true
+    profilingEnabled: true
+    version: "0"
+  monitoring:
+    namespaced: true
+    podMonitor:
+      enabled: true
+  replicas: 2

--- a/performance/ceramic-new-streams/simulation.yaml
+++ b/performance/ceramic-new-streams/simulation.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: "keramik.3box.io/v1alpha1"
+kind: Simulation
+metadata:
+  name: ceramic-new-streams
+  namespace: keramik-ceramic-new-streams
+spec:
+  scenario: ceramic-new-streams
+  users: 20
+  runTime: 5
+  throttleRequests: 100


### PR DESCRIPTION
A workflow that can be manually triggered for running keramik performance tests from yaml in this repo under `/performance`.

This workflow is to be called from a future cron based action to schedule periodic runs.
https://docs.github.com/en/actions/using-workflows/reusing-workflows

You can test the `ceramic-new-streams` config now by using this branch in the action.

The `ceramic-anchoring-benchmark` example requires a keramik operator update.

Closes INFRA-99