### PR TITLE
fix: pnpm action version

### DIFF
--- a/.github/workflows/check_build_test.yml
+++ b/.github/workflows/check_build_test.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: pnpm/action-setup@v2
+    - uses: pnpm/action-setup@v4
       with:
         package_json_file: suite/package.json
     - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
Update pnpm install action version to avoid `ERR_INVALID_THIS` when installing using node v20.