### PR TITLE
feat: run hermetic experimental tests

### DIFF
--- a/networks/experimental-rust.yaml
+++ b/networks/experimental-rust.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: "keramik.3box.io/v1alpha1"
+kind: Network
+metadata:
+  name: experimental-rust
+spec:
+  replicas: 2
+  ceramic:
+    - image: "ceramicnetwork/composedb:dev"
+      imagePullPolicy: Always # Ensures the image is always pulled before starting the pod
+      ipfs:
+        rust:
+          env:
+            CERAMIC_ONE_EXPERIMENTAL_FEATURES: "true"
+            CERAMIC_ONE_EVENT_VALIDATION: "true"
+          resourceLimits:
+            cpu: "4"
+            memory: "1Gi"
+  # Use Kubo with CAS because it still needs pubsub
+  cas:
+    casResourceLimits:
+      cpu: "2"
+      memory: "4Gi"
+    ipfs:
+      go: {}
+  monitoring:
+    namespaced: true


### PR DESCRIPTION
This change adds a network config that runs ceramic one with some experimental flags.

The first flag to test is the event validation