### PR TITLE
chore: set eth rpc url for keramik

### DIFF
--- a/networks/basic-rust.yaml
+++ b/networks/basic-rust.yaml
@@ -14,6 +14,7 @@ spec:
         rust:
           env:
             CERAMIC_ONE_RECON: "true"
+            CERAMIC_ONE_ETHEREUM_RPC_URLS: "http://ganache:8545"
           resourceLimits:
             cpu: "4"
             memory: "1Gi"

--- a/networks/experimental-rust.yaml
+++ b/networks/experimental-rust.yaml
@@ -13,6 +13,7 @@ spec:
           env:
             CERAMIC_ONE_EXPERIMENTAL_FEATURES: "true"
             CERAMIC_ONE_EVENT_VALIDATION: "true"
+            CERAMIC_ONE_ETHEREUM_RPC_URLS: "http://ganache:8545"
           resourceLimits:
             cpu: "4"
             memory: "1Gi"


### PR DESCRIPTION
We default to localhost in the code but keramik needs to address by container name, so the default is changed here. We use the env var for now as the CLI flag isn't merged yet so this var is ignored until that is merged.