### PR TITLE
feat: add flight-sql support

### DIFF
--- a/hermetic/src/cli/process-peers.sh
+++ b/hermetic/src/cli/process-peers.sh
@@ -16,6 +16,7 @@ until [ "$n" -ge 30 ];
       mkdir /config/env
 
       CERAMIC_URLS=$(jq -j '[.[].ceramic.ipfsRpcAddr | select(.)] | join(",")' < /peers/peers.json)
+      CERAMIC_FLIGHT_URLS=$(jq -j '[.[].ceramic.flightAddr | select(.)] | join(",")' < /peers/peers.json)
       COMPOSEDB_URLS=$(jq -j '[.[].ceramic.ceramicAddr | select(.)] | join(",")' < /peers/peers.json)
 
       # Set up the env var with admin DID seeds to be a comma separated list with the same secret
@@ -31,6 +32,7 @@ until [ "$n" -ge 30 ];
       done
 
       echo "CERAMIC_URLS=$CERAMIC_URLS" > /config/.env
+      echo "CERAMIC_FLIGHT_URLS=$CERAMIC_FLIGHT_URLS" >> /config/.env
       echo "COMPOSEDB_URLS=$COMPOSEDB_URLS" >> /config/.env
       echo "COMPOSEDB_ADMIN_DID_SEEDS=$COMPOSEDB_ADMIN_DID_SEEDS" >> /config/.env
 

--- a/networks/experimental-rust.yaml
+++ b/networks/experimental-rust.yaml
@@ -19,6 +19,9 @@ spec:
             CERAMIC_ONE_REMOTE_ANCHOR_SERVICE_URL: "http://cas:8081"
             CERAMIC_ONE_ANCHOR_INTERVAL: 1
             CERAMIC_ONE_ANCHOR_POLL_INTERVAL: 5
+            CERAMIC_ONE_FLIGHT_SQL_BIND_ADDRESS: "http://localhost:5102"
+            CERAMIC_ONE_AGGREGATOR: "true"
+            CERAMIC_ONE_OBJECT_STORE_URL: "file://./pipeline"
           resourceLimits:
             cpu: "4"
             memory: "1Gi"

--- a/port-forward.sh
+++ b/port-forward.sh
@@ -19,6 +19,7 @@ fi
 
 composedb=7007
 ceramic=5101
+flight=5102
 offset=1
 step=1
 
@@ -26,26 +27,30 @@ admin_private_key=$(kubectl $namespace_flag get secret ceramic-admin -o jsonpath
 
 COMPOSEDB_URLS=''
 CERAMIC_URLS=''
+CERAMIC_FLIGHT_URLS=''
 COMPOSEDB_ADMIN_DID_SEEDS=''
 
 for pod in $(kubectl $namespace_flag get pods -l app=ceramic -o json | jq -r '.items[].metadata.name')
 do
     composedb_local=$((composedb + offset))
     ceramic_local=$((ceramic + offset))
+    flight_local=$((flight + offset))
 
     if [ $offset != 1 ]
     then
         COMPOSEDB_URLS="$COMPOSEDB_URLS,"
         CERAMIC_URLS="$CERAMIC_URLS,"
+        CERAMIC_FLIGHT_URLS="$CERAMIC_FLIGHT_URLS,"
         COMPOSEDB_ADMIN_DID_SEEDS="$COMPOSEDB_ADMIN_DID_SEEDS,"
     fi
 
 
     COMPOSEDB_URLS="${COMPOSEDB_URLS}http://localhost:$composedb_local"
     CERAMIC_URLS="${CERAMIC_URLS}http://localhost:$ceramic_local"
+    CERAMIC_FLIGHT_URLS="${CERAMIC_FLIGHT_URLS}http://localhost:$flight_local"
     COMPOSEDB_ADMIN_DID_SEEDS="${COMPOSEDB_ADMIN_DID_SEEDS}${admin_private_key}"
 
-    kubectl port-forward $namespace_flag "$pod" $composedb_local:$composedb $ceramic_local:$ceramic >/dev/null  &
+    kubectl port-forward $namespace_flag "$pod" $composedb_local:$composedb $ceramic_local:$ceramic  $flight_local:$flight >/dev/null  &
 
     offset=$((offset + step))
 done
@@ -53,4 +58,5 @@ done
 
 export COMPOSEDB_URLS
 export CERAMIC_URLS
+export CERAMIC_FLIGHT_URLS
 export COMPOSEDB_ADMIN_DID_SEEDS

--- a/suite/env/.env.dev
+++ b/suite/env/.env.dev
@@ -1,5 +1,6 @@
 ANCHOR_INTERVAL_MIN=780
 COMPOSEDB_URLS=http://keramik-ceramic-v4-dev-tailscale-0-0:7007,http://keramik-ceramic-v4-dev-tailscale-0-1:7007
 CERAMIC_URLS=http://keramik-ceramic-v4-dev-tailscale-0-0:5101,http://keramik-ceramic-v4-dev-tailscale-0-1:5101
+CERAMIC_FLIGHT_URLS=http://keramik-ceramic-v4-dev-tailscale-0-0:5102,http://keramik-ceramic-v4-dev-tailscale-0-1:5102
 NETWORK=dev-unstable
 STAGE=dev

--- a/suite/env/.env.prod
+++ b/suite/env/.env.prod
@@ -1,5 +1,6 @@
 ANCHOR_INTERVAL_MIN=1440
 COMPOSEDB_URLS=http://keramik-ceramic-v4-prod-tailscale-0-0:7007,http://keramik-ceramic-v4-prod-tailscale-0-1:7007
 CERAMIC_URLS=http://keramik-ceramic-v4-prod-tailscale-0-0:5101,http://keramik-ceramic-v4-prod-tailscale-0-1:5101
+CERAMIC_FLIGHT_URLS=http://keramik-ceramic-v4-prod-tailscale-0-0:5102,http://keramik-ceramic-v4-prod-tailscale-0-1:5102
 NETWORK=mainnet
 STAGE=prod

--- a/suite/env/.env.qa
+++ b/suite/env/.env.qa
@@ -1,5 +1,6 @@
 ANCHOR_INTERVAL_MIN=780
 COMPOSEDB_URLS=http://keramik-ceramic-v4-qa-tailscale-0-0:7007,http://keramik-ceramic-v4-qa-tailscale-0-1:7007
 CERAMIC_URLS=http://keramik-ceramic-v4-qa-tailscale-0-0:5101,http://keramik-ceramic-v4-qa-tailscale-0-1:5101
+CERAMIC_FLIGHT_URLS=http://keramik-ceramic-v4-qa-tailscale-0-0:5102,http://keramik-ceramic-v4-qa-tailscale-0-1:5102
 NETWORK=dev-unstable
 STAGE=qa

--- a/suite/env/.env.tnet
+++ b/suite/env/.env.tnet
@@ -1,5 +1,6 @@
 ANCHOR_INTERVAL_MIN=1440
 COMPOSEDB_URLS=http://keramik-ceramic-v4-tnet-tailscale-0-0:7007,http://keramik-ceramic-v4-tnet-tailscale-0-1:7007
 CERAMIC_URLS=http://keramik-ceramic-v4-tnet-tailscale-0-0:5101,http://keramik-ceramic-v4-tnet-tailscale-0-1:5101
+CERAMIC_FLIGHT_URLS=http://keramik-ceramic-v4-tnet-tailscale-0-0:5102,http://keramik-ceramic-v4-tnet-tailscale-0-1:5102
 NETWORK=testnet-clay
 STAGE=tnet


### PR DESCRIPTION
Enables flight sql for the experimental-rust network and updates envs with info about where flight-sql can be found.